### PR TITLE
Fix borders for code structure highlighting.

### DIFF
--- a/src/editor/codemirror/structure-highlighting/theme.ts
+++ b/src/editor/codemirror/structure-highlighting/theme.ts
@@ -18,6 +18,14 @@ export const baseTheme = EditorView.baseTheme({
   ".cm-cs--block": {
     borderRadius: "var(--chakra-radii-lg)",
   },
+  // Disable border radius when it looks bad.
+  ".cm-cs--lshapes .cm-cs--block": {
+    borderRadius: "unset",
+  },
+  ".cm-cs--borders-left-edge-only .cm-cs--block": {
+    borderRadius: "unset",
+  },
+
   ".cm-cs--background-block .cm-cs--block": {
     backgroundColor: "var(--chakra-colors-code-block)",
   },
@@ -52,7 +60,7 @@ export const baseTheme = EditorView.baseTheme({
   },
 
   // boxes full border
-  ".cm-cs--boxes.cm-cs--borders-border .cm-cs--block": {
+  ".cm-cs--boxes.cm-cs--borders-borders .cm-cs--block": {
     border: "2px solid var(--chakra-colors-code-border)",
   },
 });

--- a/src/editor/codemirror/structure-highlighting/visual-block.ts
+++ b/src/editor/codemirror/structure-highlighting/visual-block.ts
@@ -73,7 +73,7 @@ export class VisualBlock {
       body.style.left = this.body.left - bodyPullBack + "px";
       body.style.top = this.body.top + "px";
       body.style.height = this.body.height + "px";
-      body.style.width = `calc(100% - ${this.body.left}px)`;
+      body.style.width = `calc(100% - ${this.body.left - bodyPullBack}px)`;
     }
 
     if (this.parent && parent && this.body && body && indent) {


### PR DESCRIPTION
Avoid rounding where it's problematic. If we want it we need to draw
another box or switch to SVG.

Fix a failure to account for bodyPullBack in the body element's width.

See #207 