### PR TITLE
Updated indent behaviour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13393,6 +13393,14 @@
         "lezer-tree": "^0.13.2"
       }
     },
+    "lezer-python": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/lezer-python/-/lezer-python-0.13.7.tgz",
+      "integrity": "sha512-IoUdd88Hj2rdzV74xis5/NLWe69+GRe8wTI1z8ZIl/0IbyMAWEEvSHzAKqBGNGTuBIpBaW+l8awbW4gSZqrjIw==",
+      "requires": {
+        "lezer": "^0.13.2"
+      }
+    },
     "lezer-tree": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/lezer-tree/-/lezer-tree-0.13.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2637,8 +2637,9 @@
       }
     },
     "@codemirror/lang-python": {
-      "version": "github:microbit-matt-hillsdon/lang-python#8826375bddefd0de6b834254dce5563b80cded4e",
-      "from": "github:microbit-matt-hillsdon/lang-python#indent-rethink-build",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-0.18.1.tgz",
+      "integrity": "sha512-qvlacd/sVb7ZZ4wTkOyWDL2P/OU98peChCvZRNyk8+w4bLHWfljoJRmiTGpZCdiwQtPq4IkEOl+xC/K8W0Sqig==",
       "requires": {
         "@codemirror/highlight": "^0.18.0",
         "@codemirror/language": "^0.18.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2637,9 +2637,8 @@
       }
     },
     "@codemirror/lang-python": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-0.18.1.tgz",
-      "integrity": "sha512-qvlacd/sVb7ZZ4wTkOyWDL2P/OU98peChCvZRNyk8+w4bLHWfljoJRmiTGpZCdiwQtPq4IkEOl+xC/K8W0Sqig==",
+      "version": "github:microbit-matt-hillsdon/lang-python#8826375bddefd0de6b834254dce5563b80cded4e",
+      "from": "github:microbit-matt-hillsdon/lang-python#indent-rethink-build",
       "requires": {
         "@codemirror/highlight": "^0.18.0",
         "@codemirror/language": "^0.18.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2636,16 +2636,6 @@
         "@codemirror/view": "^0.18.0"
       }
     },
-    "@codemirror/lang-python": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-0.18.1.tgz",
-      "integrity": "sha512-qvlacd/sVb7ZZ4wTkOyWDL2P/OU98peChCvZRNyk8+w4bLHWfljoJRmiTGpZCdiwQtPq4IkEOl+xC/K8W0Sqig==",
-      "requires": {
-        "@codemirror/highlight": "^0.18.0",
-        "@codemirror/language": "^0.18.0",
-        "lezer-python": "^0.13.0"
-      }
-    },
     "@codemirror/language": {
       "version": "0.18.2",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.18.2.tgz",
@@ -13401,14 +13391,6 @@
       "integrity": "sha512-cAiMQZGUo2BD8mpcz7Nv1TlKzWP7YIdIRrX41CiP5bk5t4GHxskOxWUx2iAOuHlz8dO+ivbuXr0J1bfHsWD+lQ==",
       "requires": {
         "lezer-tree": "^0.13.2"
-      }
-    },
-    "lezer-python": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/lezer-python/-/lezer-python-0.13.7.tgz",
-      "integrity": "sha512-IoUdd88Hj2rdzV74xis5/NLWe69+GRe8wTI1z8ZIl/0IbyMAWEEvSHzAKqBGNGTuBIpBaW+l8awbW4gSZqrjIw==",
-      "requires": {
-        "lezer": "^0.13.2"
       }
     },
     "lezer-tree": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@codemirror/gutter": "^0.18.4",
     "@codemirror/highlight": "^0.18.4",
     "@codemirror/history": "^0.18.1",
-    "@codemirror/lang-python": "^0.18.1",
+    "@codemirror/lang-python": "microbit-matt-hillsdon/lang-python#indent-rethink-build",
     "@codemirror/language": "^0.18.2",
     "@codemirror/lint": "^0.18.3",
     "@codemirror/matchbrackets": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@codemirror/gutter": "^0.18.4",
     "@codemirror/highlight": "^0.18.4",
     "@codemirror/history": "^0.18.1",
-    "@codemirror/lang-python": "microbit-matt-hillsdon/lang-python#indent-rethink-build",
+    "@codemirror/lang-python": "^0.18.1",
     "@codemirror/language": "^0.18.2",
     "@codemirror/lint": "^0.18.3",
     "@codemirror/matchbrackets": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "dapjs": "2.2.0",
     "file-saver": "^2.0.5",
     "framer-motion": "^3.10.6",
+    "lezer-python": "^0.13.7",
     "lodash.sortby": "^4.7.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@codemirror/gutter": "^0.18.4",
     "@codemirror/highlight": "^0.18.4",
     "@codemirror/history": "^0.18.1",
-    "@codemirror/lang-python": "^0.18.1",
     "@codemirror/language": "^0.18.2",
     "@codemirror/lint": "^0.18.3",
     "@codemirror/matchbrackets": "^0.18.0",

--- a/src/editor/codemirror/config.ts
+++ b/src/editor/codemirror/config.ts
@@ -22,7 +22,7 @@ import { commentKeymap } from "@codemirror/comment";
 import { defaultHighlightStyle } from "@codemirror/highlight";
 import { lintKeymap } from "@codemirror/lint";
 import { EditorView } from "@codemirror/view";
-import { python } from "@codemirror/lang-python";
+import { python } from "./lang-python";
 import { completion } from "./completion";
 import highlightStyle from "./highlightStyle";
 

--- a/src/editor/codemirror/lang-python.ts
+++ b/src/editor/codemirror/lang-python.ts
@@ -1,0 +1,131 @@
+// Couldn't persude codesandbox to use a GH branch as a dep so inlined from
+// https://github.com/microbit-matt-hillsdon/lang-python/blob/indent-rethink/src/python.ts
+import { parser } from "lezer-python";
+import {
+  delimitedIndent,
+  indentNodeProp,
+  foldNodeProp,
+  foldInside,
+  LezerLanguage,
+  LanguageSupport,
+  TreeIndentContext,
+} from "@codemirror/language";
+import { styleTags, tags as t } from "@codemirror/highlight";
+import { SyntaxNode } from "lezer-tree";
+
+function shouldDedentAfter(node: SyntaxNode, pos: number): boolean {
+  switch (node.type.name) {
+    case "BreakStatement":
+    case "ContinueStatement":
+    case "PassStatement":
+      return true;
+    // For return and raise we need to check we're not in the expression.
+    case "RaiseStatement":
+    case "ReturnStatement":
+      return pos >= node.to;
+    default:
+      return false;
+  }
+}
+
+function bodyIndent(context: TreeIndentContext) {
+  // Indentation is significant in Python so modify it with care.
+  let currentIndent = context.lineIndent(context.state.doc.lineAt(context.pos));
+  let childBefore = context.node.childBefore(context.pos);
+  if (childBefore && shouldDedentAfter(childBefore, context.pos))
+    return context.baseIndent;
+
+  let nodeBefore = context.node.resolve(context.pos, -1);
+  let isBodyStart = nodeBefore && nodeBefore.name === ":";
+  if (isBodyStart) return context.baseIndent + context.unit;
+  return currentIndent;
+}
+
+/// A language provider based on the [Lezer Python
+/// parser](https://github.com/lezer-parser/python), extended with
+/// highlighting and indentation information.
+export const pythonLanguage = LezerLanguage.define({
+  parser: parser.configure({
+    props: [
+      indentNodeProp.add({
+        Body: bodyIndent,
+        ArgList: delimitedIndent({ closing: ")" }),
+        ArrayExpression: delimitedIndent({ closing: "]" }),
+        DictionaryExpression: delimitedIndent({ closing: "}" }),
+        ParamList: delimitedIndent({ closing: ")" }),
+        ParenthesizedExpression: delimitedIndent({ closing: ")" }),
+        TupleExpression: delimitedIndent({ closing: ")" }),
+        Script: (context) => {
+          let currentIndent = context.lineIndent(
+            context.state.doc.lineAt(context.pos)
+          );
+          if (
+            context.pos + /\s*/.exec(context.textAfter)![0].length <
+            context.node.to
+          ) {
+            return currentIndent;
+          }
+          // Position at the end of the document isn't inside a trailing body so adjust.
+          let lastNode = context.node.resolve(context.pos, -1);
+          for (let cur: SyntaxNode | null = lastNode; cur; cur = cur.parent)
+            if (cur.type.name == "Body")
+              return bodyIndent(
+                // @ts-ignore
+                new TreeIndentContext(context, context.pos, cur)
+              );
+          return currentIndent;
+        },
+      }),
+      foldNodeProp.add({
+        "Body ArrayExpression DictionaryExpression TupleExpression": foldInside,
+      }),
+      styleTags({
+        "async '*' '**' FormatConversion": t.modifier,
+        "for while if elif else try except finally return raise break continue with pass assert await yield":
+          t.controlKeyword,
+        "in not and or is del": t.operatorKeyword,
+        "import from def class global nonlocal lambda": t.definitionKeyword,
+        "with as print": t.keyword,
+        self: t.self,
+        Boolean: t.bool,
+        None: t.null,
+        VariableName: t.variableName,
+        "CallExpression/VariableName": t.function(t.variableName),
+        "FunctionDefinition/VariableName": t.function(
+          t.definition(t.variableName)
+        ),
+        "ClassDefinition/VariableName": t.definition(t.className),
+        PropertyName: t.propertyName,
+        "CallExpression/MemberExpression/PropertyName": t.function(
+          t.propertyName
+        ),
+        Comment: t.lineComment,
+        Number: t.number,
+        String: t.string,
+        FormatString: t.special(t.string),
+        UpdateOp: t.updateOperator,
+        ArithOp: t.arithmeticOperator,
+        BitOp: t.bitwiseOperator,
+        CompareOp: t.compareOperator,
+        AssignOp: t.definitionOperator,
+        Ellipsis: t.punctuation,
+        At: t.meta,
+        "( )": t.paren,
+        "[ ]": t.squareBracket,
+        "{ }": t.brace,
+        ".": t.derefOperator,
+        ", ;": t.separator,
+      }),
+    ],
+  }),
+  languageData: {
+    closeBrackets: { brackets: ["(", "[", "{", "'", '"', "'''", '"""'] },
+    commentTokens: { line: "#" },
+    indentOnInput: /^\s*[\}\]\)]$/,
+  },
+});
+
+/// Python language support.
+export function python() {
+  return new LanguageSupport(pythonLanguage);
+}

--- a/src/editor/codemirror/lang-python.ts
+++ b/src/editor/codemirror/lang-python.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Couldn't persude codesandbox to use a GH branch as a dep so inlined from
 // https://github.com/microbit-matt-hillsdon/lang-python/blob/indent-rethink/src/python.ts
 import { parser } from "lezer-python";


### PR DESCRIPTION
Inlines https://github.com/microbit-matt-hillsdon/lang-python/tree/indent-rethink for the moment for testing.

Hopefully there'll be upstream interest in something similar to this rather than maintaining it this way.

We could also consider publishing a package. Depending on a GitHub branch doesn't seem to play well with installing the private theme package for reasons I don't really fancy debugging.