### PR TITLE
First stab at configuring xterm.js keys.

### DIFF
--- a/src/serial/XTerm.tsx
+++ b/src/serial/XTerm.tsx
@@ -18,6 +18,7 @@ import {
 import { EVENT_SERIAL_DATA, EVENT_SERIAL_RESET } from "../device/device";
 import { useDevice } from "../device/device-hooks";
 import "./xterm-custom.css";
+import customKeyEventHandler from "./xterm-keyboard";
 
 const ptToPixelRatio = 96 / 72;
 
@@ -46,6 +47,7 @@ const XTerm = (props: BoxProps) => {
       });
       const fitAddon = new FitAddon();
       term.loadAddon(fitAddon);
+      term.attachCustomKeyEventHandler(customKeyEventHandler);
       term.open(ref.current);
 
       let firstWrite = true;

--- a/src/serial/xterm-keyboard.ts
+++ b/src/serial/xterm-keyboard.ts
@@ -1,0 +1,31 @@
+const copyShortcut = (e: KeyboardEvent): boolean => {
+  console.log(e.key);
+  if (e.ctrlKey && e.shiftKey && e.key === "C") {
+    e.preventDefault();
+    document.execCommand("copy");
+    return false;
+  }
+  return true;
+};
+
+const softRebootShortcut = (e: KeyboardEvent) => {
+  if (e.ctrlKey && e.key === "d") {
+    // MicroPython handles this as a soft reboot.
+    // Avoid it also adding a bookmark! (Ctrl-D on Windows/Linux)
+    e.preventDefault();
+    e.stopPropagation();
+  }
+  return true;
+};
+
+const handlers = [copyShortcut, softRebootShortcut];
+const customKeyEventHandler = (e: KeyboardEvent): boolean => {
+  for (const handler of handlers) {
+    if (!handler(e)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+export default customKeyEventHandler;

--- a/src/serial/xterm-keyboard.ts
+++ b/src/serial/xterm-keyboard.ts
@@ -1,6 +1,5 @@
 const copyShortcut = (e: KeyboardEvent): boolean => {
-  console.log(e.key);
-  if (e.ctrlKey && e.shiftKey && e.key === "C") {
+  if (e.ctrlKey && e.shiftKey && e.code === "KeyC") {
     e.preventDefault();
     document.execCommand("copy");
     return false;
@@ -8,17 +7,30 @@ const copyShortcut = (e: KeyboardEvent): boolean => {
   return true;
 };
 
-const softRebootShortcut = (e: KeyboardEvent) => {
-  if (e.ctrlKey && e.key === "d") {
-    // MicroPython handles this as a soft reboot.
-    // Avoid it also adding a bookmark! (Ctrl-D on Windows/Linux)
+const isMicroPythonCtrlShortcut = (code: string) => {
+  // Editing keys are here: https://github.com/micropython/micropython/blob/46a11028521425e7d6c85458c849bb96ff82152e/lib/mp-readline/readline.c
+  switch (code) {
+    case "KeyA":
+    case "KeyB":
+    case "KeyC":
+    case "KeyD":
+    case "KeyE":
+      return true;
+    default:
+      return false;
+  }
+};
+
+const micropythonShortcuts = (e: KeyboardEvent) => {
+  if (e.ctrlKey && isMicroPythonCtrlShortcut(e.code)) {
+    // Avoid also triggering browser shortcuts, e.g. bookmark (Ctrl+D), search (Ctrl+E).
     e.preventDefault();
     e.stopPropagation();
   }
   return true;
 };
 
-const handlers = [copyShortcut, softRebootShortcut];
+const handlers = [copyShortcut, micropythonShortcuts];
 const customKeyEventHandler = (e: KeyboardEvent): boolean => {
   for (const handler of handlers) {
     if (!handler(e)) {


### PR DESCRIPTION
Attempt to avoid clash with Ctrl-D browser shortcut on Windows.

Provide alternative copy shortcut (Mac works fine with Cmd+C but Windows
has a clash with Ctrl-C).

I think paste is working via a paste event sent via the browser and we
can't trigger it ourselves for browser security reasons. On Mac Cmd-V
and Shift-Insert work. Yet to test this on Windows.

TODO:
- [x] Test on Windows
- Discuss more discoverable UX, perhaps after merging a serial toolbar / status bar.
    - Moved to https://github.com/microbit-foundation/python-editor-next/issues/220

Closes https://github.com/microbit-foundation/python-editor-next/issues/217