### PR TITLE
Show runtime errors in compact serial view

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ _steps:
   install_dependencies: &install_dependencies
     run: npm ci --cache .npm-cache && sudo npm i -g --registry https://npm.pkg.github.com/microbit-foundation @microbit-foundation/website-deploy-aws@0.2.0 @microbit-foundation/website-deploy-aws-config@0.4.2 @microbit-foundation/circleci-npm-package-versioner@1
   install_theme: &install_theme
-    run: npm install --no-save --registry https://npm.pkg.github.com/microbit-foundation @microbit-foundation/python-editor-next-microbit@0.1.0-dev.37
+    run: npm install --no-save --registry https://npm.pkg.github.com/microbit-foundation @microbit-foundation/python-editor-next-microbit@0.1.0-dev.43
   update_version: &update_version
     run: npm run ci:update-version
   build: &build

--- a/lang/en.json
+++ b/lang/en.json
@@ -347,6 +347,14 @@
     "defaultMessage": "Replace",
     "description": "Action label for replacing project dialog"
   },
+  "serial-collapse": {
+    "defaultMessage": "Collapse the serial terminal",
+    "description": "Aria label for serial expand/collapse"
+  },
+  "serial-expand": {
+    "defaultMessage": "Expand the serial terminal",
+    "description": "Aria label for serial expand/collapse"
+  },
   "serial-terminal": {
     "defaultMessage": "Serial terminal",
     "description": "Aria label for the serial terminal"

--- a/lang/en.json
+++ b/lang/en.json
@@ -235,6 +235,10 @@
     "defaultMessage": "Highlight code structure",
     "description": "Highlight code option text"
   },
+  "hints-and-tips": {
+    "defaultMessage": "Hints and tips",
+    "description": "Link/button for minor internal help"
+  },
   "language": {
     "defaultMessage": "Language",
     "description": "Language option text"
@@ -351,9 +355,45 @@
     "defaultMessage": "Collapse the serial terminal",
     "description": "Aria label for serial expand/collapse"
   },
+  "serial-ctrl-c-button": {
+    "defaultMessage": "Send Ctrl-C for REPL",
+    "description": "Button to trigger the Python REPL from the serial area"
+  },
+  "serial-ctrl-d-button": {
+    "defaultMessage": "Send Ctrl-D to reset",
+    "description": "Button to reset the micro:bit from the serial area"
+  },
   "serial-expand": {
     "defaultMessage": "Expand the serial terminal",
     "description": "Aria label for serial expand/collapse"
+  },
+  "serial-help-ctrl-c": {
+    "defaultMessage": "Use the keyboard shortcut <kbd>Ctrl</kbd> + <kbd>C</kbd> to interrupt your program. Then you can type Python commands for MicroPython to run. It's a great way to experiment with something new.",
+    "description": "Text from the serial hints and tips dialog. kbd tag shows a keyboard key style."
+  },
+  "serial-help-ctrl-d": {
+    "defaultMessage": "To start your program running again use <kbd>Ctrl</kbd> <kbd>D</kbd>.",
+    "description": "Text from the serial hints and tips dialog.  kbd tag shows a keyboard key style."
+  },
+  "serial-help-intro": {
+    "defaultMessage": "The serial terminal shows errors and other output from the program running on your micro:bit. By default, it shows the most recent error from the program. Expand it to see all the output.",
+    "description": "Text from the serial hints and tips dialog"
+  },
+  "serial-help-print": {
+    "defaultMessage": "Your program can print messages using the <code>print</code> function. Try adding <code>print('micro:bit is awesome')</code> to your program.",
+    "description": "Text from the serial hints and tips dialog. code tag shows monospaced font."
+  },
+  "serial-help-title": {
+    "defaultMessage": "Serial hints and tips",
+    "description": "Title for the serial hints and tips dialog"
+  },
+  "serial-menu": {
+    "defaultMessage": "Serial menu",
+    "description": "Aria label for serial area menu"
+  },
+  "serial-running": {
+    "defaultMessage": "Running…",
+    "description": "Indicator text when the micro:bit is running a program"
   },
   "serial-terminal": {
     "defaultMessage": "Serial terminal",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21557,7 +21557,8 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
     },
     "workbox-background-sync": {
       "version": "5.1.4",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "react-icons": "^4.2.0",
     "react-intl": "^5.20.4",
     "web-vitals": "^1.1.1",
-    "word-wrap": "^1.2.3",
     "xterm": "^4.13.0",
     "xterm-addon-fit": "^0.5.0"
   },

--- a/src/common/ExpandCollapseIcon.tsx
+++ b/src/common/ExpandCollapseIcon.tsx
@@ -1,0 +1,10 @@
+import { ChevronDownIcon, ChevronUpIcon, IconProps } from "@chakra-ui/icons";
+
+interface ExpandCollapseIconProps extends IconProps {
+  open: boolean;
+}
+
+const ExpandCollapseIcon = ({ open, ...props }: ExpandCollapseIconProps) =>
+  open ? <ChevronUpIcon {...props} /> : <ChevronDownIcon {...props} />;
+
+export default ExpandCollapseIcon;

--- a/src/common/SplitView/SplitView.tsx
+++ b/src/common/SplitView/SplitView.tsx
@@ -19,10 +19,13 @@ import {
 } from "./context";
 import SplitViewSized from "./SplitViewSized";
 
+export type SizedMode = "collapsed" | "compact" | "open";
+
 interface SplitViewProps extends Omit<FlexProps, "children" | "direction"> {
-  collapsed?: boolean;
+  mode?: SizedMode;
   children: [JSX.Element, JSX.Element, JSX.Element];
   direction: Direction;
+  compactSize?: number;
   minimums: [number, number];
 }
 
@@ -37,7 +40,8 @@ export const SplitView = ({
   children,
   direction,
   minimums,
-  collapsed = false,
+  mode = "open",
+  compactSize = 0,
   ...props
 }: SplitViewProps) => {
   const sizedFirst = children[0].type === SplitViewSized;
@@ -131,7 +135,8 @@ export const SplitView = ({
 
   const context: SplitViewContext = useMemo(() => {
     return {
-      collapsed,
+      mode,
+      compactSize,
       sizedPaneSize,
       setSizedPaneSize,
       direction,
@@ -141,7 +146,8 @@ export const SplitView = ({
       handleTouchEndOrMouseUp,
     };
   }, [
-    collapsed,
+    mode,
+    compactSize,
     sizedPaneSize,
     setSizedPaneSize,
     direction,

--- a/src/common/SplitView/SplitViewDivider.tsx
+++ b/src/common/SplitView/SplitViewDivider.tsx
@@ -7,14 +7,14 @@ import { Box, Flex } from "@chakra-ui/react";
 
 const SplitViewDivider = () => {
   const {
-    collapsed,
+    mode,
     direction,
     handleMouseDown,
     handleTouchStart,
     handleTouchEndOrMouseUp,
   } = useSplitViewContext();
   const cursor = direction === "row" ? "col-resize" : "row-resize";
-  return collapsed ? null : (
+  return mode !== "open" ? null : (
     <Flex
       onMouseDown={handleMouseDown}
       onTouchStart={handleTouchStart}

--- a/src/common/SplitView/SplitViewRemainer.tsx
+++ b/src/common/SplitView/SplitViewRemainer.tsx
@@ -10,19 +10,19 @@ import { Box } from "@chakra-ui/layout";
  * The pane that takes the remaining space.
  */
 const SplitViewRemainder = ({ children }: { children: ReactNode }) => {
-  const { direction, sizedPaneSize, collapsed } = useSplitViewContext();
-  return (
-    <Box
-      {...dimensionProps(
-        direction,
-        collapsed
-          ? "100%"
-          : `calc(100% - ${sizedPaneSize}px - ${separatorPixels}px)`
-      )}
-    >
-      {children}
-    </Box>
-  );
+  const { direction, sizedPaneSize, compactSize, mode } = useSplitViewContext();
+  // We're the remainder, so figure out our size given the other cases.
+  const remainingSpace = (() => {
+    switch (mode) {
+      case "collapsed":
+        return "100%";
+      case "open":
+        return `calc(100% - ${sizedPaneSize}px - ${separatorPixels}px)`;
+      case "compact":
+        return `calc(100% - ${compactSize}px)`;
+    }
+  })();
+  return <Box {...dimensionProps(direction, remainingSpace)}>{children}</Box>;
 };
 
 export default SplitViewRemainder;

--- a/src/common/SplitView/SplitViewSized.tsx
+++ b/src/common/SplitView/SplitViewSized.tsx
@@ -12,17 +12,25 @@ interface SizedPaneProps {
  * The other pane takes the remaining space.
  */
 const SplitViewSized = ({ children }: SizedPaneProps) => {
-  const { direction, sizedPaneSize, collapsed } = useSplitViewContext();
+  const { direction, sizedPaneSize, compactSize, mode } = useSplitViewContext();
   const ref = createRef<HTMLDivElement>();
   useEffect(() => {
     if (ref.current) {
-      ref.current.style[dimensionPropName(direction)] = collapsed
-        ? "0px"
-        : `${sizedPaneSize}px`;
+      const size = (() => {
+        switch (mode) {
+          case "collapsed":
+            return "0px";
+          case "open":
+            return `${sizedPaneSize}px`;
+          case "compact":
+            return `${compactSize}px`;
+        }
+      })();
+      ref.current.style[dimensionPropName(direction)] = size;
     }
-  }, [ref, collapsed, direction, sizedPaneSize]);
+  }, [ref, mode, direction, sizedPaneSize, compactSize]);
   return (
-    <Box visibility={collapsed ? "hidden" : undefined} ref={ref}>
+    <Box visibility={mode === "collapsed" ? "hidden" : undefined} ref={ref}>
       {children}
     </Box>
   );

--- a/src/common/SplitView/context.tsx
+++ b/src/common/SplitView/context.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext } from "react";
+import { SizedMode } from "./SplitView";
 
 export const separatorPixels = 5;
 
@@ -20,7 +21,8 @@ export const dimensionProps = (
 };
 
 export interface SplitViewContext {
-  collapsed: boolean;
+  mode: SizedMode;
+  compactSize: number;
   sizedPaneSize: number | undefined;
   setSizedPaneSize: (v: number) => void;
   direction: Direction;

--- a/src/common/zIndex.ts
+++ b/src/common/zIndex.ts
@@ -1,0 +1,2 @@
+// z-index above the xterm.js's layers (currently 10 but given some margin for increases as it can vary with config)
+export const zIndexAboveTerminal = 20;

--- a/src/deployment/default/colors.ts
+++ b/src/deployment/default/colors.ts
@@ -22,6 +22,8 @@ const colors = {
     literal: "darkgreen",
     string: "green",
     activeLine: theme.colors.gray[100],
+
+    error: theme.colors.red[500], // Match default error toast
   },
 };
 

--- a/src/device/device-hooks.test.tsx
+++ b/src/device/device-hooks.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * (c) 2021, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { TracebackScrollback } from "./device-hooks";
+
+const toCrLf = (text: string): string =>
+  text.replace(/[\r\n]/g, "\n").replace(/\n/g, "\r\n");
+
+describe("TracebackScrollback", () => {
+  it("matches tracebacks", () => {
+    const tsb = new TracebackScrollback();
+    const traceback = tsb.push(
+      toCrLf(`
+Misc output
+>>> Other stuff
+Not a traceback
+Traceback (most recent call last):
+  File "main.py", line 7, in <module>
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+  File "main.py", line 5, in foo
+RuntimeError: maximum recursion depth exceeded
+
+>>> Other stuff
+`)
+    )!;
+    expect(traceback.error).toEqual(
+      "RuntimeError: maximum recursion depth exceeded"
+    );
+    expect(traceback.trace[0]).toEqual('File "main.py", line 7, in <module>');
+    expect(traceback.trace[traceback.trace.length - 1]).toEqual(
+      'File "main.py", line 5, in foo'
+    );
+    expect(traceback.line).toEqual(5);
+    expect(traceback.file).toEqual("main.py");
+  });
+  it("finds the last one", () => {
+    const tsb = new TracebackScrollback();
+    const traceback = tsb.push(
+      toCrLf(`Traceback (most recent call last):
+  File "main.py", line 5, in foo
+RuntimeError: 1
+Traceback (most recent call last):
+  File "main.py", line 5, in foo
+RuntimeError: 2
+`)
+    )!;
+    expect(traceback.error).toEqual("RuntimeError: 2");
+  });
+
+  it("skips direct REPL interaction as indicated by <stdin>", () => {
+    const tsb = new TracebackScrollback();
+    const traceback = tsb.push(
+      toCrLf(`>>> bar()
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File "main.py", line 5, in bar
+ValueError: Wow!`)
+    );
+
+    expect(traceback).toBeUndefined();
+  });
+
+  it("skips direct REPL interaction as indicated by KeyboardInterrupt", () => {
+    const tsb = new TracebackScrollback();
+    const traceback = tsb.push(
+      toCrLf(`Traceback (most recent call last):
+  File "main.py", line 10, in <module>
+KeyboardInterrupt:`)
+    );
+
+    expect(traceback).toBeUndefined();
+  });
+
+  it("identifies file and line from last line of trace", () => {
+    const tsb = new TracebackScrollback();
+    const traceback = tsb.push(
+      toCrLf(`Traceback (most recent call last):
+  File "main.py", line 10, in <module>
+  File "foo.py", line 11, in <module>
+  File "bar.py", line 12, in <module>
+InsufficientCaffine:`)
+    )!;
+
+    expect(traceback.file).toBe("bar.py");
+    expect(traceback.line).toBe(12);
+  });
+
+  it("limits scrollback", () => {
+    const tsb = new TracebackScrollback();
+    let traceback;
+    traceback = tsb.push(
+      toCrLf(`Traceback (most recent call last):
+  File "main.py", line 10, in <module>
+SomeError:
+`)
+    )!;
+    expect(traceback).toBeDefined();
+    traceback = tsb.push(toCrLf("0".repeat(5000)))!;
+    expect(traceback).toBeUndefined();
+  });
+});

--- a/src/device/device-hooks.ts
+++ b/src/device/device-hooks.ts
@@ -8,6 +8,9 @@ import {
   MicrobitWebUSBConnection,
   EVENT_STATUS,
   ConnectionStatus,
+  EVENT_SERIAL_DATA,
+  EVENT_SERIAL_RESET,
+  EVENT_SERIAL_ERROR,
 } from "./device";
 
 export const DeviceContext = React.createContext<
@@ -44,4 +47,139 @@ export const useConnectionStatus = () => {
   }, [device, setStatus]);
 
   return status;
+};
+
+interface TraceLineParts {
+  file: string | undefined;
+  line: number | undefined;
+}
+const unknownParts: TraceLineParts = { line: undefined, file: undefined };
+
+/**
+ * Parse a line from the trace of a traceback.
+ *
+ * Trims leading/trailing space and returns undefined files
+ * if it does not match the expected format.
+ */
+export const parseTraceLine = (line: string): TraceLineParts => {
+  // E.g.
+  // File "main.py", line 5, in foo
+  // File "<stdin>", line 1, in <module>
+  const match = /^File [<"]([^>"]+)[">], line (\d+)/.exec(line.trim());
+  if (match) {
+    let file: string | undefined = match[1];
+    let line: number | undefined;
+    const number = match[2];
+    if (number) {
+      line = parseInt(number, 10);
+    }
+    return { line, file };
+  }
+  return unknownParts;
+};
+
+export class Traceback {
+  private parsed?: TraceLineParts;
+
+  constructor(public error: string, public trace: string[]) {}
+
+  private parse(): TraceLineParts {
+    if (this.parsed) {
+      return this.parsed;
+    }
+    const trace = this.trace[this.trace.length - 1];
+    if (trace) {
+      this.parsed = parseTraceLine(trace);
+    } else {
+      this.parsed = unknownParts;
+    }
+    return this.parsed;
+  }
+
+  get line(): number | undefined {
+    return this.parse().line;
+  }
+
+  get file(): string | undefined {
+    const file = this.parse().file;
+    switch (file) {
+      case "stdin":
+        return undefined;
+      default:
+        return file;
+    }
+  }
+}
+
+export class TracebackScrollback {
+  private scrollback: string = "";
+  push(data: string) {
+    this.scrollback = this.scrollback + data;
+    const limit = 4096;
+    if (this.scrollback.length > limit) {
+      this.scrollback = this.scrollback.slice(data.length - limit);
+    }
+    const lines = this.scrollback.split("\r\n");
+    for (let i = lines.length - 1; i >= 0; --i) {
+      if (lines[i].startsWith("Traceback (most recent call last):")) {
+        // Start of last traceback
+        // Skip all following lines with an indent and grab the first one without, which is the error message.
+        let endOfIndent = i + 1;
+        while (
+          endOfIndent < lines.length &&
+          lines[endOfIndent].startsWith("  ")
+        ) {
+          endOfIndent++;
+        }
+        if (endOfIndent < lines.length) {
+          const trace = lines
+            .slice(i + 1, endOfIndent)
+            .map((line) => line.trim());
+          if (trace[0] && trace[0].startsWith('File "<stdin>"')) {
+            // User entered code at the REPL, discard.
+            return undefined;
+          }
+          const error = lines[endOfIndent];
+          if (error.startsWith("KeyboardInterrupt")) {
+            // User interrupted the program (we assume), discard.
+            return undefined;
+          }
+          return new Traceback(error, trace);
+        }
+        return undefined;
+      }
+    }
+    return undefined;
+  }
+  clear() {
+    this.scrollback = "";
+  }
+}
+
+export const useDeviceTraceback = () => {
+  const device = useDevice();
+  const [runtimeError, setRuntimeError] = useState<Traceback | undefined>(
+    undefined
+  );
+
+  useEffect(() => {
+    const buffer = new TracebackScrollback();
+    const dataListener = (data: string) => {
+      setRuntimeError(buffer.push(data));
+    };
+    const clearListener = () => {
+      buffer.clear();
+      setRuntimeError(undefined);
+    };
+    device.addListener(EVENT_SERIAL_DATA, dataListener);
+    device.addListener(EVENT_SERIAL_RESET, clearListener);
+    device.addListener(EVENT_SERIAL_ERROR, clearListener);
+    return () => {
+      device.removeListener(EVENT_SERIAL_ERROR, clearListener);
+      device.removeListener(EVENT_SERIAL_RESET, clearListener);
+      device.removeListener(EVENT_SERIAL_DATA, dataListener);
+    };
+  }, [device, setRuntimeError]);
+
+  return runtimeError;
 };

--- a/src/editor/EditorArea.tsx
+++ b/src/editor/EditorArea.tsx
@@ -7,12 +7,13 @@ import { Box, BoxProps, Flex, Link } from "@chakra-ui/react";
 import { useIntl } from "react-intl";
 import { useDeployment } from "../deployment";
 import ProjectNameEditable from "../project/ProjectNameEditable";
+import { WorkbenchSelection } from "../workbench/use-selection";
 import ActiveFileInfo from "./ActiveFileInfo";
 import EditorContainer from "./EditorContainer";
 import ZoomControls from "./ZoomControls";
 
 interface EditorAreaProps extends BoxProps {
-  filename: string;
+  selection: WorkbenchSelection;
   onSelectedFileChanged: (filename: string) => void;
 }
 
@@ -21,7 +22,7 @@ interface EditorAreaProps extends BoxProps {
  * and wires it to the currently open file.
  */
 const EditorArea = ({
-  filename,
+  selection,
   onSelectedFileChanged,
   ...props
 }: EditorAreaProps) => {
@@ -48,7 +49,7 @@ const EditorArea = ({
       >
         <ProjectNameEditable />
         <ActiveFileInfo
-          filename={filename}
+          filename={selection.file}
           onSelectedFileChanged={onSelectedFileChanged}
         />
         <Link
@@ -82,7 +83,7 @@ const EditorArea = ({
           right={spacingFromRight}
           position="absolute"
         />
-        <EditorContainer filename={filename} />
+        <EditorContainer selection={selection} />
       </Box>
     </Flex>
   );

--- a/src/editor/EditorContainer.tsx
+++ b/src/editor/EditorContainer.tsx
@@ -5,22 +5,24 @@
  */
 import { useProjectFileText } from "../project/project-hooks";
 import { useSettings } from "../settings/settings";
+import { WorkbenchSelection } from "../workbench/use-selection";
 import Editor from "./codemirror/CodeMirror";
 
 interface EditorContainerProps {
-  filename: string;
+  selection: WorkbenchSelection;
 }
 
 /**
  * Container for the editor that integrates it with the app settings
  * and wires it to the currently open file.
  */
-const EditorContainer = ({ filename }: EditorContainerProps) => {
+const EditorContainer = ({ selection }: EditorContainerProps) => {
   const [{ fontSize, codeStructureHighlight }] = useSettings();
-  const [defaultValue, onFileChange] = useProjectFileText(filename);
+  const [defaultValue, onFileChange] = useProjectFileText(selection.file);
   return typeof defaultValue === "undefined" ? null : (
     <Editor
       defaultValue={defaultValue}
+      location={selection.location}
       onChange={onFileChange}
       fontSize={fontSize}
       codeStructureHighlight={codeStructureHighlight}

--- a/src/editor/codemirror/CodeMirror.tsx
+++ b/src/editor/codemirror/CodeMirror.tsx
@@ -108,7 +108,7 @@ const CodeMirror = ({
   }, [options]);
 
   useEffect(() => {
-    // When identify of location changes then the user has navigated.
+    // When the identity of location changes then the user has navigated.
     if (location.line) {
       const view = viewRef.current!;
       let line;

--- a/src/editor/codemirror/CodeMirror.tsx
+++ b/src/editor/codemirror/CodeMirror.tsx
@@ -3,11 +3,12 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { EditorState } from "@codemirror/state";
+import { EditorSelection, EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { useEffect, useMemo, useRef } from "react";
 import { useIntl } from "react-intl";
 import { CodeStructureHighlight } from "../../settings/settings";
+import { FileLocation } from "../../workbench/use-selection";
 import "./CodeMirror.css";
 import { editorConfig, themeExtensionsCompartment } from "./config";
 import {
@@ -21,6 +22,7 @@ interface CodeMirrorProps {
   defaultValue: string;
   onChange: (doc: string) => void;
 
+  location: FileLocation;
   fontSize: number;
   codeStructureHighlight: CodeStructureHighlight;
 }
@@ -37,6 +39,7 @@ const CodeMirror = ({
   defaultValue,
   className,
   onChange,
+  location,
   fontSize,
   codeStructureHighlight,
 }: CodeMirrorProps) => {
@@ -103,6 +106,26 @@ const CodeMirror = ({
       ],
     });
   }, [options]);
+
+  useEffect(() => {
+    // When identify of location changes then the user has navigated.
+    if (location.line) {
+      const view = viewRef.current!;
+      let line;
+      try {
+        line = view.state.doc.line(location.line);
+      } catch (e) {
+        // Document doesn't have that line, e.g. link from stale error
+        // after a code edit.
+        return;
+      }
+      view.dispatch({
+        scrollIntoView: true,
+        selection: EditorSelection.single(line.from),
+      });
+      view.focus();
+    }
+  }, [location]);
 
   return (
     <section

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -695,6 +695,18 @@
       "value": "Replace"
     }
   ],
+  "serial-collapse": [
+    {
+      "type": 0,
+      "value": "Collapse the serial terminal"
+    }
+  ],
+  "serial-expand": [
+    {
+      "type": 0,
+      "value": "Expand the serial terminal"
+    }
+  ],
   "serial-terminal": [
     {
       "type": 0,

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -453,6 +453,12 @@
       "value": "Highlight code structure"
     }
   ],
+  "hints-and-tips": [
+    {
+      "type": 0,
+      "value": "Hints and tips"
+    }
+  ],
   "language": [
     {
       "type": 0,
@@ -701,10 +707,148 @@
       "value": "Collapse the serial terminal"
     }
   ],
+  "serial-ctrl-c-button": [
+    {
+      "type": 0,
+      "value": "Send Ctrl-C for REPL"
+    }
+  ],
+  "serial-ctrl-d-button": [
+    {
+      "type": 0,
+      "value": "Send Ctrl-D to reset"
+    }
+  ],
   "serial-expand": [
     {
       "type": 0,
       "value": "Expand the serial terminal"
+    }
+  ],
+  "serial-help-ctrl-c": [
+    {
+      "type": 0,
+      "value": "Use the keyboard shortcut "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "Ctrl"
+        }
+      ],
+      "type": 8,
+      "value": "kbd"
+    },
+    {
+      "type": 0,
+      "value": " + "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "C"
+        }
+      ],
+      "type": 8,
+      "value": "kbd"
+    },
+    {
+      "type": 0,
+      "value": " to interrupt your program. Then you can type Python commands for MicroPython to run. It's a great way to experiment with something new."
+    }
+  ],
+  "serial-help-ctrl-d": [
+    {
+      "type": 0,
+      "value": "To start your program running again use "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "Ctrl"
+        }
+      ],
+      "type": 8,
+      "value": "kbd"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "D"
+        }
+      ],
+      "type": 8,
+      "value": "kbd"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "serial-help-intro": [
+    {
+      "type": 0,
+      "value": "The serial terminal shows errors and other output from the program running on your micro:bit. By default, it shows the most recent error from the program. Expand it to see all the output."
+    }
+  ],
+  "serial-help-print": [
+    {
+      "type": 0,
+      "value": "Your program can print messages using the "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "print"
+        }
+      ],
+      "type": 8,
+      "value": "code"
+    },
+    {
+      "type": 0,
+      "value": " function. Try adding "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "print('micro:bit is awesome')"
+        }
+      ],
+      "type": 8,
+      "value": "code"
+    },
+    {
+      "type": 0,
+      "value": " to your program."
+    }
+  ],
+  "serial-help-title": [
+    {
+      "type": 0,
+      "value": "Serial hints and tips"
+    }
+  ],
+  "serial-menu": [
+    {
+      "type": 0,
+      "value": "Serial menu"
+    }
+  ],
+  "serial-running": [
+    {
+      "type": 0,
+      "value": "Running…"
     }
   ],
   "serial-terminal": [

--- a/src/project/DownloadFlashButton.tsx
+++ b/src/project/DownloadFlashButton.tsx
@@ -17,6 +17,7 @@ import {
 import { MdMoreVert } from "react-icons/md";
 import { RiDownload2Line, RiFlashlightFill } from "react-icons/ri";
 import { FormattedMessage } from "react-intl";
+import { zIndexAboveTerminal } from "../common/zIndex";
 import { ConnectionStatus } from "../device/device";
 import { useConnectionStatus } from "../device/device-hooks";
 import DownloadButton from "./DownloadButton";
@@ -63,8 +64,7 @@ const DownloadFlashButton = ({ size }: DownloadFlashButtonProps) => {
             size={size}
           />
           <Portal>
-            {/* z-index above the xterm.js's layers (currently 10 but given some margin for increases as it can vary with config) */}
-            <MenuList zIndex={20}>
+            <MenuList zIndex={zIndexAboveTerminal}>
               {!connected && (
                 <MenuItem
                   target="_blank"

--- a/src/project/project-actions.tsx
+++ b/src/project/project-actions.tsx
@@ -26,6 +26,7 @@ import {
   readFileAsUint8Array,
 } from "../fs/fs-util";
 import { Logging } from "../logging/logging";
+import { WorkbenchSelection } from "../workbench/use-selection";
 import {
   ClassifiedFileInput,
   FileChange,
@@ -64,7 +65,7 @@ export class ProjectActions {
     private device: MicrobitWebUSBConnection,
     private actionFeedback: ActionFeedback,
     private dialogs: Dialogs,
-    private setSelection: (filename: string) => void,
+    private setSelection: (selection: WorkbenchSelection) => void,
     private intl: IntlShape,
     private logging: Logging
   ) {}
@@ -402,7 +403,7 @@ export class ProjectActions {
           "# Your new file!",
           VersionAction.INCREMENT
         );
-        this.setSelection(filename);
+        this.setSelection({ file: filename, location: { line: undefined } });
         this.actionFeedback.success({
           title: this.intl.formatMessage({ id: "created-file" }, { filename }),
         });

--- a/src/project/project-hooks.tsx
+++ b/src/project/project-hooks.tsx
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useIntl } from "react-intl";
 import useActionFeedback from "../common/use-action-feedback";
 import { useDialogs } from "../common/use-dialogs";
 import useIsUnmounted from "../common/use-is-unmounted";
@@ -13,7 +14,6 @@ import { useFileSystem } from "../fs/fs-hooks";
 import { useLogging } from "../logging/logging-hooks";
 import { useSelection } from "../workbench/use-selection";
 import { ProjectActions } from "./project-actions";
-import { useIntl } from "react-intl";
 
 /**
  * Hook exposing the main UI actions.

--- a/src/serial/MaybeTracebackLink.tsx
+++ b/src/serial/MaybeTracebackLink.tsx
@@ -1,0 +1,29 @@
+/**
+ * (c) 2021, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { Traceback } from "../device/device-hooks";
+import { MAIN_FILE } from "../fs/fs";
+import TracebackLink from "./TracebackLink";
+
+interface MaybeTracebackLinkProps {
+  traceback: Traceback;
+}
+
+const MaybeTracebackLink = ({ traceback }: MaybeTracebackLinkProps) => {
+  const { file, line } = traceback;
+  if (file === MAIN_FILE && line) {
+    return <TracebackLink traceback={traceback}>line {line}</TracebackLink>;
+  }
+  if (file && line) {
+    return (
+      <TracebackLink traceback={traceback}>
+        {file} line {line}
+      </TracebackLink>
+    );
+  }
+  return null;
+};
+
+export default MaybeTracebackLink;

--- a/src/serial/SerialArea.tsx
+++ b/src/serial/SerialArea.tsx
@@ -3,12 +3,34 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { BoxProps, Flex } from "@chakra-ui/react";
+import {
+  Box,
+  BoxProps,
+  Flex,
+  HStack,
+  Icon,
+  IconButton,
+  Text,
+} from "@chakra-ui/react";
+import { useCallback } from "react";
+import { RiErrorWarningLine, RiTerminalBoxLine } from "react-icons/ri";
+import { useIntl } from "react-intl";
+import ExpandCollapseIcon from "../common/ExpandCollapseIcon";
+import { backgroundColorTerm } from "../deployment/misc";
 import { ConnectionStatus } from "../device/device";
-import { useConnectionStatus } from "../device/device-hooks";
+import {
+  useConnectionStatus,
+  useDeviceTraceback,
+} from "../device/device-hooks";
+import MaybeTracebackLink from "./MaybeTracebackLink";
 import XTerm from "./XTerm";
 
-const SerialArea = (props: BoxProps) => {
+interface SerialAreaProps extends BoxProps {
+  compact?: boolean;
+  onSizeChange: (size: "compact" | "open") => void;
+}
+
+const SerialArea = ({ compact, onSizeChange, ...props }: SerialAreaProps) => {
   const connected = useConnectionStatus() === ConnectionStatus.CONNECTED;
   return (
     <Flex
@@ -19,8 +41,82 @@ const SerialArea = (props: BoxProps) => {
       position="relative"
       overflow="hidden"
     >
-      {!connected ? null : <XTerm flex="1 1 auto" height={0} />}
+      {!connected ? null : (
+        <Box
+          alignItems="stretch"
+          backgroundColor={backgroundColorTerm}
+          spacing={0}
+          height="100%"
+        >
+          <SerialBar
+            height={12}
+            compact={compact}
+            onSizeChange={onSizeChange}
+          />
+          <XTerm
+            visibility={compact ? "hidden" : undefined}
+            height={`calc(100% - ${SerialArea.compactSize}px)`}
+            ml={1}
+            mr={1}
+          />
+        </Box>
+      )}
     </Flex>
+  );
+};
+SerialArea.compactSize = 48;
+
+interface SerialBarProps extends BoxProps {
+  compact?: boolean;
+  onSizeChange: (size: "compact" | "open") => void;
+}
+
+const SerialBar = ({ compact, onSizeChange, ...props }: SerialBarProps) => {
+  const handleExpandCollapseClick = useCallback(() => {
+    onSizeChange(compact ? "open" : "compact");
+  }, [compact, onSizeChange]);
+  const intl = useIntl();
+  return (
+    <HStack justifyContent="space-between" p={1} {...props}>
+      <SerialIndicators compact={compact} overflow="hidden" />
+      <IconButton
+        variant="sidebar"
+        color="white"
+        isRound
+        aria-label={
+          compact
+            ? intl.formatMessage({ id: "serial-expand" })
+            : intl.formatMessage({ id: "serial-collapse" })
+        }
+        icon={<ExpandCollapseIcon open={Boolean(compact)} />}
+        onClick={handleExpandCollapseClick}
+      />
+    </HStack>
+  );
+};
+
+interface SerialIndicatorsProps extends BoxProps {
+  compact?: boolean;
+}
+
+const SerialIndicators = ({ compact, ...props }: SerialIndicatorsProps) => {
+  const traceback = useDeviceTraceback();
+  return (
+    <HStack {...props}>
+      <Icon m={1} as={RiTerminalBoxLine} fill="white" boxSize={5} />
+      {compact && (
+        <HStack spacing={0}>
+          {traceback && (
+            <>
+              <Icon m={1} as={RiErrorWarningLine} fill="white" boxSize={5} />
+              <Text color="white" whiteSpace="nowrap">
+                <MaybeTracebackLink traceback={traceback} /> {traceback.error}
+              </Text>
+            </>
+          )}
+        </HStack>
+      )}
+    </HStack>
   );
 };
 

--- a/src/serial/SerialArea.tsx
+++ b/src/serial/SerialArea.tsx
@@ -3,26 +3,12 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import {
-  Box,
-  BoxProps,
-  Flex,
-  HStack,
-  Icon,
-  IconButton,
-  Text,
-} from "@chakra-ui/react";
-import { useCallback } from "react";
-import { RiErrorWarningLine, RiTerminalBoxLine } from "react-icons/ri";
-import { useIntl } from "react-intl";
-import ExpandCollapseIcon from "../common/ExpandCollapseIcon";
+import { Box, BoxProps, Flex } from "@chakra-ui/react";
 import { backgroundColorTerm } from "../deployment/misc";
 import { ConnectionStatus } from "../device/device";
-import {
-  useConnectionStatus,
-  useDeviceTraceback,
-} from "../device/device-hooks";
-import MaybeTracebackLink from "./MaybeTracebackLink";
+import { useConnectionStatus } from "../device/device-hooks";
+import { TerminalContext } from "./serial-hooks";
+import SerialBar from "./SerialBar";
 import XTerm from "./XTerm";
 
 interface SerialAreaProps extends BoxProps {
@@ -33,91 +19,39 @@ interface SerialAreaProps extends BoxProps {
 const SerialArea = ({ compact, onSizeChange, ...props }: SerialAreaProps) => {
   const connected = useConnectionStatus() === ConnectionStatus.CONNECTED;
   return (
-    <Flex
-      {...props}
-      flexDirection="column"
-      alignItems="stretch"
-      height="100%"
-      position="relative"
-      overflow="hidden"
-    >
-      {!connected ? null : (
-        <Box
-          alignItems="stretch"
-          backgroundColor={backgroundColorTerm}
-          spacing={0}
-          height="100%"
-        >
-          <SerialBar
-            height={12}
-            compact={compact}
-            onSizeChange={onSizeChange}
-          />
-          <XTerm
-            visibility={compact ? "hidden" : undefined}
-            height={`calc(100% - ${SerialArea.compactSize}px)`}
-            ml={1}
-            mr={1}
-          />
-        </Box>
-      )}
-    </Flex>
+    <TerminalContext>
+      <Flex
+        {...props}
+        flexDirection="column"
+        alignItems="stretch"
+        height="100%"
+        position="relative"
+        overflow="hidden"
+      >
+        {!connected ? null : (
+          <Box
+            alignItems="stretch"
+            backgroundColor={backgroundColorTerm}
+            spacing={0}
+            height="100%"
+          >
+            <SerialBar
+              height={12}
+              compact={compact}
+              onSizeChange={onSizeChange}
+            />
+            <XTerm
+              visibility={compact ? "hidden" : undefined}
+              height={`calc(100% - ${SerialArea.compactSize}px)`}
+              ml={1}
+              mr={1}
+            />
+          </Box>
+        )}
+      </Flex>
+    </TerminalContext>
   );
 };
 SerialArea.compactSize = 48;
-
-interface SerialBarProps extends BoxProps {
-  compact?: boolean;
-  onSizeChange: (size: "compact" | "open") => void;
-}
-
-const SerialBar = ({ compact, onSizeChange, ...props }: SerialBarProps) => {
-  const handleExpandCollapseClick = useCallback(() => {
-    onSizeChange(compact ? "open" : "compact");
-  }, [compact, onSizeChange]);
-  const intl = useIntl();
-  return (
-    <HStack justifyContent="space-between" p={1} {...props}>
-      <SerialIndicators compact={compact} overflow="hidden" />
-      <IconButton
-        variant="sidebar"
-        color="white"
-        isRound
-        aria-label={
-          compact
-            ? intl.formatMessage({ id: "serial-expand" })
-            : intl.formatMessage({ id: "serial-collapse" })
-        }
-        icon={<ExpandCollapseIcon open={Boolean(compact)} />}
-        onClick={handleExpandCollapseClick}
-      />
-    </HStack>
-  );
-};
-
-interface SerialIndicatorsProps extends BoxProps {
-  compact?: boolean;
-}
-
-const SerialIndicators = ({ compact, ...props }: SerialIndicatorsProps) => {
-  const traceback = useDeviceTraceback();
-  return (
-    <HStack {...props}>
-      <Icon m={1} as={RiTerminalBoxLine} fill="white" boxSize={5} />
-      {compact && (
-        <HStack spacing={0}>
-          {traceback && (
-            <>
-              <Icon m={1} as={RiErrorWarningLine} fill="white" boxSize={5} />
-              <Text color="white" whiteSpace="nowrap">
-                <MaybeTracebackLink traceback={traceback} /> {traceback.error}
-              </Text>
-            </>
-          )}
-        </HStack>
-      )}
-    </HStack>
-  );
-};
 
 export default SerialArea;

--- a/src/serial/SerialBar.tsx
+++ b/src/serial/SerialBar.tsx
@@ -11,7 +11,7 @@ import {
   useDisclosure,
 } from "@chakra-ui/react";
 import { useCallback } from "react";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import ExpandCollapseIcon from "../common/ExpandCollapseIcon";
 import { SerialHelpDialog } from "./SerialHelp";
 import SerialIndicators from "./SerialIndicators";
@@ -45,7 +45,7 @@ const SerialBar = ({ compact, onSizeChange, ...props }: SerialBarProps) => {
             color="white"
             onClick={helpDisclosure.onOpen}
           >
-            Hints and tips
+            <FormattedMessage id="hints-and-tips" />
           </Button>
           <HStack spacing={0}>
             <IconButton

--- a/src/serial/SerialBar.tsx
+++ b/src/serial/SerialBar.tsx
@@ -1,3 +1,8 @@
+/**
+ * (c) 2021, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
 import {
   BoxProps,
   Button,

--- a/src/serial/SerialBar.tsx
+++ b/src/serial/SerialBar.tsx
@@ -13,6 +13,7 @@ import {
 import { useCallback } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import ExpandCollapseIcon from "../common/ExpandCollapseIcon";
+import { useDeviceTraceback } from "../device/device-hooks";
 import { SerialHelpDialog } from "./SerialHelp";
 import SerialIndicators from "./SerialIndicators";
 import SerialMenu from "./SerialMenu";
@@ -22,20 +23,35 @@ interface SerialBarProps extends BoxProps {
   onSizeChange: (size: "compact" | "open") => void;
 }
 
-const SerialBar = ({ compact, onSizeChange, ...props }: SerialBarProps) => {
+const SerialBar = ({
+  compact,
+  onSizeChange,
+  background,
+  ...props
+}: SerialBarProps) => {
   const handleExpandCollapseClick = useCallback(() => {
     onSizeChange(compact ? "open" : "compact");
   }, [compact, onSizeChange]);
   const intl = useIntl();
   const helpDisclosure = useDisclosure();
+  const traceback = useDeviceTraceback();
   return (
     <>
       <SerialHelpDialog
         isOpen={helpDisclosure.isOpen}
         onClose={helpDisclosure.onClose}
       />
-      <HStack justifyContent="space-between" p={1} {...props}>
-        <SerialIndicators compact={compact} overflow="hidden" />
+      <HStack
+        justifyContent="space-between"
+        p={1}
+        backgroundColor={traceback && "code.error"}
+        {...props}
+      >
+        <SerialIndicators
+          compact={compact}
+          traceback={traceback}
+          overflow="hidden"
+        />
 
         <HStack>
           <Button

--- a/src/serial/SerialBar.tsx
+++ b/src/serial/SerialBar.tsx
@@ -1,0 +1,70 @@
+import {
+  BoxProps,
+  Button,
+  HStack,
+  IconButton,
+  useDisclosure,
+} from "@chakra-ui/react";
+import { useCallback } from "react";
+import { useIntl } from "react-intl";
+import ExpandCollapseIcon from "../common/ExpandCollapseIcon";
+import { SerialHelpDialog } from "./SerialHelp";
+import SerialIndicators from "./SerialIndicators";
+import SerialMenu from "./SerialMenu";
+
+interface SerialBarProps extends BoxProps {
+  compact?: boolean;
+  onSizeChange: (size: "compact" | "open") => void;
+}
+
+const SerialBar = ({ compact, onSizeChange, ...props }: SerialBarProps) => {
+  const handleExpandCollapseClick = useCallback(() => {
+    onSizeChange(compact ? "open" : "compact");
+  }, [compact, onSizeChange]);
+  const intl = useIntl();
+  const helpDisclosure = useDisclosure();
+  return (
+    <>
+      <SerialHelpDialog
+        isOpen={helpDisclosure.isOpen}
+        onClose={helpDisclosure.onClose}
+      />
+      <HStack justifyContent="space-between" p={1} {...props}>
+        <SerialIndicators compact={compact} overflow="hidden" />
+
+        <HStack>
+          <Button
+            variant="unstyled"
+            fontWeight="normal"
+            textDecoration="underline"
+            color="white"
+            onClick={helpDisclosure.onOpen}
+          >
+            Hints and tips
+          </Button>
+          <HStack spacing={0}>
+            <IconButton
+              variant="sidebar"
+              color="white"
+              isRound
+              aria-label={
+                compact
+                  ? intl.formatMessage({ id: "serial-expand" })
+                  : intl.formatMessage({ id: "serial-collapse" })
+              }
+              icon={<ExpandCollapseIcon open={Boolean(compact)} />}
+              onClick={handleExpandCollapseClick}
+            />
+            <SerialMenu
+              compact={compact}
+              onSizeChange={onSizeChange}
+              onOpenHelp={helpDisclosure.onOpen}
+            />
+          </HStack>
+        </HStack>
+      </HStack>
+    </>
+  );
+};
+
+export default SerialBar;

--- a/src/serial/SerialHelp.tsx
+++ b/src/serial/SerialHelp.tsx
@@ -13,12 +13,18 @@ import {
   ModalOverlay,
 } from "@chakra-ui/modal";
 import { Code, Kbd, Text, VStack } from "@chakra-ui/react";
+import { ReactNode } from "react";
 import { FormattedMessage } from "react-intl";
 
 interface SerialHelpDialogProps {
   isOpen: boolean;
   onClose: () => void;
 }
+
+const formatValues = {
+  code: (chunks: ReactNode) => <Code>{chunks}</Code>,
+  kbd: (chunks: ReactNode) => <Kbd>{chunks}</Kbd>,
+};
 
 /**
  * Settings dialog.
@@ -32,29 +38,30 @@ export const SerialHelpDialog = ({
       <ModalOverlay>
         <ModalContent>
           <ModalHeader fontSize="lg" fontWeight="bold">
-            Serial hints and tips
+            <FormattedMessage id="serial-help-title" />
           </ModalHeader>
           <ModalBody>
             <VStack spacing={5} alignItems="stretch">
               <Text>
-                The serial terminal shows errors and other output from the
-                program running on your micro:bit. By default, it shows the most
-                recent error from the program. Expand it to see all the output.
+                <FormattedMessage id="serial-help-intro" />
               </Text>
               <Text>
-                Your program can print messages using the <Code>print</Code>{" "}
-                function. Try adding <Code>print('micro:bit is awesome')</Code>{" "}
-                to your program.
+                <FormattedMessage
+                  id="serial-help-print"
+                  values={formatValues}
+                />
               </Text>
               <Text>
-                Use the keyboard shortcut <Kbd>Ctrl</Kbd> + <Kbd>C</Kbd> to
-                interrupt your program. Then you can type Python commands for
-                MicroPython to run. It's a great way to experiment with
-                something new.
+                <FormattedMessage
+                  id="serial-help-ctrl-c"
+                  values={formatValues}
+                />
               </Text>
               <Text>
-                To start your program running again use <Kbd>Ctrl</Kbd> +{" "}
-                <Kbd>D</Kbd>.
+                <FormattedMessage
+                  id="serial-help-ctrl-d"
+                  values={formatValues}
+                />
               </Text>
             </VStack>
           </ModalBody>

--- a/src/serial/SerialHelp.tsx
+++ b/src/serial/SerialHelp.tsx
@@ -1,0 +1,70 @@
+/**
+ * (c) 2021, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { Button } from "@chakra-ui/button";
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from "@chakra-ui/modal";
+import { Code, Kbd, Text, VStack } from "@chakra-ui/react";
+import { FormattedMessage } from "react-intl";
+
+interface SerialHelpDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Settings dialog.
+ */
+export const SerialHelpDialog = ({
+  isOpen,
+  onClose,
+}: SerialHelpDialogProps) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="lg">
+      <ModalOverlay>
+        <ModalContent>
+          <ModalHeader fontSize="lg" fontWeight="bold">
+            Serial hints and tips
+          </ModalHeader>
+          <ModalBody>
+            <VStack spacing={5} alignItems="stretch">
+              <Text>
+                The serial terminal shows errors and other output from the
+                program running on your micro:bit. By default, it shows the most
+                recent error from the program. Expand it to see all the output.
+              </Text>
+              <Text>
+                Your program can print messages using the <Code>print</Code>{" "}
+                function. Try adding <Code>print('micro:bit is awesome')</Code>{" "}
+                to your program.
+              </Text>
+              <Text>
+                Use the keyboard shortcut <Kbd>Ctrl</Kbd> + <Kbd>C</Kbd> to
+                interrupt your program. Then you can type Python commands for
+                MicroPython to run. It's a great way to experiment with
+                something new.
+              </Text>
+              <Text>
+                To start your program running again use <Kbd>Ctrl</Kbd> +{" "}
+                <Kbd>D</Kbd>.
+              </Text>
+            </VStack>
+          </ModalBody>
+          <ModalFooter>
+            <Button variant="solid" onClick={onClose}>
+              <FormattedMessage id="close-button" />
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </ModalOverlay>
+    </Modal>
+  );
+};

--- a/src/serial/SerialIndicators.tsx
+++ b/src/serial/SerialIndicators.tsx
@@ -6,15 +6,19 @@
 import { BoxProps, HStack, Icon, Text } from "@chakra-ui/react";
 import { RiErrorWarningLine, RiTerminalBoxLine } from "react-icons/ri";
 import { FormattedMessage } from "react-intl";
-import { useDeviceTraceback } from "../device/device-hooks";
+import { Traceback } from "../device/device-hooks";
 import MaybeTracebackLink from "./MaybeTracebackLink";
 
 interface SerialIndicatorsProps extends BoxProps {
   compact?: boolean;
+  traceback?: Traceback | undefined;
 }
 
-const SerialIndicators = ({ compact, ...props }: SerialIndicatorsProps) => {
-  const traceback = useDeviceTraceback();
+const SerialIndicators = ({
+  compact,
+  traceback,
+  ...props
+}: SerialIndicatorsProps) => {
   return (
     <HStack {...props}>
       <Icon m={1} as={RiTerminalBoxLine} fill="white" boxSize={5} />

--- a/src/serial/SerialIndicators.tsx
+++ b/src/serial/SerialIndicators.tsx
@@ -5,6 +5,7 @@
  */
 import { BoxProps, HStack, Icon, Text } from "@chakra-ui/react";
 import { RiErrorWarningLine, RiTerminalBoxLine } from "react-icons/ri";
+import { FormattedMessage } from "react-intl";
 import { useDeviceTraceback } from "../device/device-hooks";
 import MaybeTracebackLink from "./MaybeTracebackLink";
 
@@ -26,7 +27,11 @@ const SerialIndicators = ({ compact, ...props }: SerialIndicatorsProps) => {
             </Text>
           </>
         )}
-        {!traceback && <Text color="white">Running…</Text>}
+        {!traceback && (
+          <Text color="white">
+            <FormattedMessage id="serial-running" />
+          </Text>
+        )}
       </HStack>
     </HStack>
   );

--- a/src/serial/SerialIndicators.tsx
+++ b/src/serial/SerialIndicators.tsx
@@ -1,0 +1,30 @@
+import { BoxProps, HStack, Icon, Text } from "@chakra-ui/react";
+import { RiErrorWarningLine, RiTerminalBoxLine } from "react-icons/ri";
+import { useDeviceTraceback } from "../device/device-hooks";
+import MaybeTracebackLink from "./MaybeTracebackLink";
+
+interface SerialIndicatorsProps extends BoxProps {
+  compact?: boolean;
+}
+
+const SerialIndicators = ({ compact, ...props }: SerialIndicatorsProps) => {
+  const traceback = useDeviceTraceback();
+  return (
+    <HStack {...props}>
+      <Icon m={1} as={RiTerminalBoxLine} fill="white" boxSize={5} />
+      <HStack spacing={0}>
+        {compact && traceback && (
+          <>
+            <Icon m={1} as={RiErrorWarningLine} fill="white" boxSize={5} />
+            <Text color="white" whiteSpace="nowrap">
+              <MaybeTracebackLink traceback={traceback} /> {traceback.error}
+            </Text>
+          </>
+        )}
+        {!traceback && <Text color="white">Running…</Text>}
+      </HStack>
+    </HStack>
+  );
+};
+
+export default SerialIndicators;

--- a/src/serial/SerialIndicators.tsx
+++ b/src/serial/SerialIndicators.tsx
@@ -1,3 +1,8 @@
+/**
+ * (c) 2021, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
 import { BoxProps, HStack, Icon, Text } from "@chakra-ui/react";
 import { RiErrorWarningLine, RiTerminalBoxLine } from "react-icons/ri";
 import { useDeviceTraceback } from "../device/device-hooks";

--- a/src/serial/SerialMenu.tsx
+++ b/src/serial/SerialMenu.tsx
@@ -9,7 +9,7 @@ import {
 } from "@chakra-ui/react";
 import { MdMoreVert } from "react-icons/md";
 import { RiInformationLine, RiKeyboardBoxLine } from "react-icons/ri";
-import { FormattedMessage, useIntl } from "react-intl";
+import { useIntl } from "react-intl";
 import { zIndexAboveTerminal } from "../common/zIndex";
 import { useSerialActions } from "./serial-hooks";
 

--- a/src/serial/SerialMenu.tsx
+++ b/src/serial/SerialMenu.tsx
@@ -1,3 +1,8 @@
+/**
+ * (c) 2021, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
 import {
   IconButton,
   Menu,

--- a/src/serial/SerialMenu.tsx
+++ b/src/serial/SerialMenu.tsx
@@ -42,7 +42,7 @@ const SerialMenu = ({ compact, onOpenHelp, onSizeChange }: SerialMenuProps) => {
           </MenuItem>
           <MenuDivider />
           <MenuItem icon={<RiInformationLine />} onClick={onOpenHelp}>
-            <FormattedMessage id="help" />
+            Hints and tips
           </MenuItem>
         </MenuList>
       </Portal>

--- a/src/serial/SerialMenu.tsx
+++ b/src/serial/SerialMenu.tsx
@@ -14,7 +14,7 @@ import {
 } from "@chakra-ui/react";
 import { MdMoreVert } from "react-icons/md";
 import { RiInformationLine, RiKeyboardBoxLine } from "react-icons/ri";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import { zIndexAboveTerminal } from "../common/zIndex";
 import { useSerialActions } from "./serial-hooks";
 
@@ -40,14 +40,14 @@ const SerialMenu = ({ compact, onOpenHelp, onSizeChange }: SerialMenuProps) => {
       <Portal>
         <MenuList zIndex={zIndexAboveTerminal}>
           <MenuItem icon={<RiKeyboardBoxLine />} onClick={actions.interrupt}>
-            Send Ctrl-C for REPL
+            <FormattedMessage id="serial-ctrl-c-button" />
           </MenuItem>
           <MenuItem icon={<RiKeyboardBoxLine />} onClick={actions.reset}>
-            Send Ctrl-D to reset
+            <FormattedMessage id="serial-ctrl-d-button" />
           </MenuItem>
           <MenuDivider />
           <MenuItem icon={<RiInformationLine />} onClick={onOpenHelp}>
-            Hints and tips
+            <FormattedMessage id="hints-and-tips" />
           </MenuItem>
         </MenuList>
       </Portal>

--- a/src/serial/SerialMenu.tsx
+++ b/src/serial/SerialMenu.tsx
@@ -1,0 +1,53 @@
+import {
+  IconButton,
+  Menu,
+  MenuButton,
+  MenuDivider,
+  MenuItem,
+  MenuList,
+  Portal,
+} from "@chakra-ui/react";
+import { MdMoreVert } from "react-icons/md";
+import { RiInformationLine, RiKeyboardBoxLine } from "react-icons/ri";
+import { FormattedMessage, useIntl } from "react-intl";
+import { zIndexAboveTerminal } from "../common/zIndex";
+import { useSerialActions } from "./serial-hooks";
+
+interface SerialMenuProps {
+  compact?: boolean;
+  onSizeChange: (size: "compact" | "open") => void;
+  onOpenHelp: () => void;
+}
+
+const SerialMenu = ({ compact, onOpenHelp, onSizeChange }: SerialMenuProps) => {
+  const intl = useIntl();
+  const actions = useSerialActions(onSizeChange);
+  return (
+    <Menu placement={compact ? "top-start" : undefined}>
+      <MenuButton
+        as={IconButton}
+        aria-label={intl.formatMessage({ id: "serial-menu" })}
+        variant="sidebar"
+        color="white"
+        isRound
+        icon={<MdMoreVert />}
+      />
+      <Portal>
+        <MenuList zIndex={zIndexAboveTerminal}>
+          <MenuItem icon={<RiKeyboardBoxLine />} onClick={actions.interrupt}>
+            Send Ctrl-C for REPL
+          </MenuItem>
+          <MenuItem icon={<RiKeyboardBoxLine />} onClick={actions.reset}>
+            Send Ctrl-D to reset
+          </MenuItem>
+          <MenuDivider />
+          <MenuItem icon={<RiInformationLine />} onClick={onOpenHelp}>
+            <FormattedMessage id="help" />
+          </MenuItem>
+        </MenuList>
+      </Portal>
+    </Menu>
+  );
+};
+
+export default SerialMenu;

--- a/src/serial/TracebackLink.tsx
+++ b/src/serial/TracebackLink.tsx
@@ -1,0 +1,39 @@
+/**
+ * (c) 2021, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { Link } from "@chakra-ui/react";
+import { ReactNode, useCallback } from "react";
+import { Traceback } from "../device/device-hooks";
+import { useSelection } from "../workbench/use-selection";
+
+interface TracebackLinkProps {
+  traceback: Traceback;
+  children: ReactNode;
+}
+
+const TracebackLink = ({ traceback, children }: TracebackLinkProps) => {
+  const [, setSelection] = useSelection();
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement>) => {
+      e.preventDefault();
+
+      const { file, line } = traceback;
+      if (file) {
+        setSelection({
+          file,
+          location: { line },
+        });
+      }
+    },
+    [setSelection, traceback]
+  );
+  return (
+    <Link textDecoration="underline" onClick={handleClick}>
+      {children}
+    </Link>
+  );
+};
+
+export default TracebackLink;

--- a/src/serial/XTerm.tsx
+++ b/src/serial/XTerm.tsx
@@ -4,145 +4,22 @@
  * SPDX-License-Identifier: MIT
  */
 import { Box, BoxProps } from "@chakra-ui/layout";
-import { useCallback, useEffect, useRef } from "react";
-import wrap from "word-wrap";
-import { Terminal } from "xterm";
-import { FitAddon } from "xterm-addon-fit";
+import { useEffect, useRef } from "react";
 import "xterm/css/xterm.css";
-import useIsUnmounted from "../common/use-is-unmounted";
-import {
-  backgroundColorTerm,
-  codeFontFamily,
-  defaultCodeFontSizePt,
-} from "../deployment/misc";
-import { EVENT_SERIAL_DATA, EVENT_SERIAL_RESET } from "../device/device";
-import { parseTraceLine, useDevice } from "../device/device-hooks";
-import { useSelection } from "../workbench/use-selection";
-import { WebLinkProvider } from "./link-provider";
+import { backgroundColorTerm } from "../deployment/misc";
+import { useTerminal } from "./serial-hooks";
 import "./xterm-custom.css";
-import customKeyEventHandler from "./xterm-keyboard";
 
-const ptToPixelRatio = 96 / 72;
+interface XTermProps extends BoxProps {}
 
-const introText = `This box will show errors and things you print. Try
-
-print('Hello, World')
-
-You can press Ctrl-C to interrupt the micro:bit program then type Python commands directly to your micro:bit
-`;
-
-// Group 1 is underlined by xterm.js
-const tracebackRegExpMatch = /^ {2}(File "[^"]+", line \d+)/;
-
-const XTerm = (props: BoxProps) => {
-  const device = useDevice();
-
+const XTerm = ({ ...props }: XTermProps) => {
   const ref = useRef<HTMLDivElement>(null);
-  const isUnmounted = useIsUnmounted();
-  const [, setSelection] = useSelection();
-  const tracebackLinkHandler = useCallback(
-    (e: MouseEvent, traceLine: string) => {
-      const { file, line } = parseTraceLine(traceLine);
-      if (file) {
-        setSelection({ file, location: { line } });
-      }
-    },
-    [setSelection]
-  );
+  const terminal = useTerminal();
   useEffect(() => {
-    if (ref.current && !isUnmounted()) {
-      const term = new Terminal({
-        fontFamily: codeFontFamily,
-        fontSize: defaultCodeFontSizePt * ptToPixelRatio,
-        letterSpacing: 1.1,
-        screenReaderMode: true,
-        theme: {
-          background: backgroundColorTerm,
-        },
-      });
-      term.registerLinkProvider(
-        new WebLinkProvider(
-          term,
-          tracebackRegExpMatch,
-          tracebackLinkHandler,
-          {}
-        )
-      );
-      const fitAddon = new FitAddon();
-      term.loadAddon(fitAddon);
-      term.attachCustomKeyEventHandler(customKeyEventHandler);
-      term.open(ref.current);
-
-      let firstWrite = true;
-      const serialListener = (data: string) => {
-        if (!isUnmounted()) {
-          if (firstWrite) {
-            // Separate from intro text. We do it now to prevent scrolling a line off unnecessarily.
-            firstWrite = false;
-            data = "\r\n\r\n" + data;
-          }
-          term.write(data);
-        }
-      };
-      const resetListener = () => {
-        if (!isUnmounted()) {
-          term.reset();
-        }
-      };
-
-      let firstResize = true;
-      term.onResize(() => {
-        // We need to wait until we have the initial size to wrap the intro text.
-        if (firstResize) {
-          firstResize = false;
-          const wrapped = wrap(introText, {
-            width: term.cols - 2,
-            newline: "\r\n",
-            trim: true,
-            indent: "",
-          });
-          term.write(wrapped, () => {
-            term.scrollToTop();
-
-            // Start listening for data.
-            device.on(EVENT_SERIAL_DATA, serialListener);
-            device.on(EVENT_SERIAL_RESET, resetListener);
-            term.onData((data: string) => {
-              if (!isUnmounted()) {
-                // Async for internal error handling, we don't need to wait.
-                device.serialWrite(data);
-              }
-            });
-          });
-        }
-      });
-
-      // Watch for resize and change terminal rows/cols accordingly.
-      // This can result in a slither of space at the bottom, so backgrounds
-      // should match.
-      const resizeObserver = new ResizeObserver((entries) => {
-        if (!Array.isArray(entries) || !entries.length) {
-          return;
-        }
-        try {
-          fitAddon.fit();
-        } catch (e) {
-          // It throws if you resize it when not visible but it does no harm.
-        }
-      });
-      resizeObserver.observe(ref.current);
-
-      return () => {
-        device.removeListener(EVENT_SERIAL_RESET, resetListener);
-        device.removeListener(EVENT_SERIAL_DATA, serialListener);
-        resizeObserver.disconnect();
-        term.dispose();
-      };
+    if (ref.current) {
+      terminal.open(ref.current);
     }
-  }, [device, isUnmounted, tracebackLinkHandler]);
-
-  // The terminal itself is sized based on the number of rows,
-  // so we need a background that matches the theme.
+  }, [terminal]);
   return <Box {...props} ref={ref} backgroundColor={backgroundColorTerm} />;
 };
 

--- a/src/serial/link-provider.ts
+++ b/src/serial/link-provider.ts
@@ -1,0 +1,160 @@
+/**
+ * WebLinkProvider from the xterm.js project. This isn't public API there
+ * but it is easily repurposed to handle other link types via different
+ * regexes.
+ * https://github.com/xtermjs/xterm.js/blob/522c8bf3afcc296f7586c21b097025fe3626dc32/addons/xterm-addon-web-links/src/WebLinkProvider.ts
+ *
+ * Copyright (c) 2019 The xterm.js authors. All rights reserved.
+ * @license MIT
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { ILinkProvider, ILink, Terminal, IViewportRange } from "xterm";
+
+interface ILinkProviderOptions {
+  hover?(event: MouseEvent, text: string, location: IViewportRange): void;
+  leave?(event: MouseEvent, text: string): void;
+}
+
+export class WebLinkProvider implements ILinkProvider {
+  constructor(
+    private readonly _terminal: Terminal,
+    private readonly _regex: RegExp,
+    private readonly _handler: (event: MouseEvent, uri: string) => void,
+    private readonly _options: ILinkProviderOptions = {}
+  ) {}
+
+  public provideLinks(
+    y: number,
+    callback: (links: ILink[] | undefined) => void
+  ): void {
+    const links = LinkComputer.computeLink(
+      y,
+      this._regex,
+      this._terminal,
+      this._handler
+    );
+    callback(this._addCallbacks(links));
+  }
+
+  private _addCallbacks(links: ILink[]): ILink[] {
+    return links.map((link) => {
+      link.leave = this._options.leave;
+      link.hover = (event: MouseEvent, uri: string): void => {
+        if (this._options.hover) {
+          const { range } = link;
+          this._options.hover(event, uri, range);
+        }
+      };
+      return link;
+    });
+  }
+}
+
+export class LinkComputer {
+  public static computeLink(
+    y: number,
+    regex: RegExp,
+    terminal: Terminal,
+    activate: (event: MouseEvent, uri: string) => void
+  ): ILink[] {
+    const rex = new RegExp(regex.source, (regex.flags || "") + "g");
+
+    const [line, startLineIndex] =
+      LinkComputer._translateBufferLineToStringWithWrap(y - 1, false, terminal);
+
+    let match;
+    let stringIndex = -1;
+    const result: ILink[] = [];
+
+    while ((match = rex.exec(line)) !== null) {
+      const text = match[1];
+      if (!text) {
+        // something matched but does not comply with the given matchIndex
+        // since this is most likely a bug the regex itself we simply do nothing here
+        console.log("match found without corresponding matchIndex");
+        break;
+      }
+
+      // Get index, match.index is for the outer match which includes negated chars
+      // therefore we cannot use match.index directly, instead we search the position
+      // of the match group in text again
+      // also correct regex and string search offsets for the next loop run
+      stringIndex = line.indexOf(text, stringIndex + 1);
+      rex.lastIndex = stringIndex + text.length;
+      if (stringIndex < 0) {
+        // invalid stringIndex (should not have happened)
+        break;
+      }
+
+      let endX = stringIndex + text.length;
+      let endY = startLineIndex + 1;
+
+      while (endX > terminal.cols) {
+        endX -= terminal.cols;
+        endY++;
+      }
+
+      const range = {
+        start: {
+          x: stringIndex + 1,
+          y: startLineIndex + 1,
+        },
+        end: {
+          x: endX,
+          y: endY,
+        },
+      };
+
+      result.push({ range, text, activate });
+    }
+
+    return result;
+  }
+
+  /**
+   * Gets the entire line for the buffer line
+   * @param line The line being translated.
+   * @param trimRight Whether to trim whitespace to the right.
+   * @param terminal The terminal
+   */
+  private static _translateBufferLineToStringWithWrap(
+    lineIndex: number,
+    trimRight: boolean,
+    terminal: Terminal
+  ): [string, number] {
+    let lineString = "";
+    let lineWrapsToNext: boolean;
+    let prevLinesToWrap: boolean;
+
+    do {
+      const line = terminal.buffer.active.getLine(lineIndex);
+      if (!line) {
+        break;
+      }
+
+      if (line.isWrapped) {
+        lineIndex--;
+      }
+
+      prevLinesToWrap = line.isWrapped;
+    } while (prevLinesToWrap);
+
+    const startLineIndex = lineIndex;
+
+    do {
+      const nextLine = terminal.buffer.active.getLine(lineIndex + 1);
+      lineWrapsToNext = nextLine ? nextLine.isWrapped : false;
+      const line = terminal.buffer.active.getLine(lineIndex);
+      if (!line) {
+        break;
+      }
+      lineString += line
+        .translateToString(!lineWrapsToNext && trimRight)
+        .substring(0, terminal.cols);
+      lineIndex++;
+    } while (lineWrapsToNext);
+
+    return [lineString, startLineIndex];
+  }
+}

--- a/src/serial/serial-actions.ts
+++ b/src/serial/serial-actions.ts
@@ -1,3 +1,8 @@
+/**
+ * (c) 2021, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
 import { MicrobitWebUSBConnection } from "../device/device";
 
 /**

--- a/src/serial/serial-actions.ts
+++ b/src/serial/serial-actions.ts
@@ -1,0 +1,19 @@
+import { MicrobitWebUSBConnection } from "../device/device";
+
+/**
+ * Serial/terminal/REPL UI-level actions.
+ */
+export class SerialActions {
+  constructor(
+    private device: MicrobitWebUSBConnection,
+    private onSerialSizeChange: (size: "compact" | "open") => void
+  ) {}
+
+  interrupt = (): void => this.sendCommand("\x03");
+  reset = (): void => this.sendCommand("\x04");
+
+  private sendCommand(data: string): void {
+    this.onSerialSizeChange("open");
+    this.device.serialWrite(data);
+  }
+}

--- a/src/serial/serial-hooks.tsx
+++ b/src/serial/serial-hooks.tsx
@@ -1,3 +1,8 @@
+/**
+ * (c) 2021, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
 import React, { ReactNode, useContext, useEffect, useMemo } from "react";
 import { Terminal } from "xterm";
 import { FitAddon } from "xterm-addon-fit";

--- a/src/serial/serial-hooks.tsx
+++ b/src/serial/serial-hooks.tsx
@@ -1,0 +1,148 @@
+import React, { ReactNode, useContext, useEffect, useMemo } from "react";
+import { Terminal } from "xterm";
+import { FitAddon } from "xterm-addon-fit";
+import useIsUnmounted from "../common/use-is-unmounted";
+import {
+  backgroundColorTerm,
+  codeFontFamily,
+  defaultCodeFontSizePt,
+} from "../deployment/misc";
+import { EVENT_SERIAL_DATA, EVENT_SERIAL_RESET } from "../device/device";
+import { parseTraceLine, useDevice } from "../device/device-hooks";
+import { useSelection } from "../workbench/use-selection";
+import { WebLinkProvider } from "./link-provider";
+import { SerialActions } from "./serial-actions";
+import customKeyEventHandler from "./xterm-keyboard";
+
+export const useSerialActions = (
+  // We should pull this out into a workspace layout context.
+  onSerialSizeChange: (size: "compact" | "open") => void
+) => {
+  const device = useDevice();
+  return useMemo(
+    () => new SerialActions(device, onSerialSizeChange),
+    [device, onSerialSizeChange]
+  );
+};
+
+const ptToPixelRatio = 96 / 72;
+
+/**
+ * Manages an XTerm terminal object.
+ *
+ * It's often useful to have this higher up the tree than its presentation
+ * so its API can be used to implement user actions.
+ */
+const useNewTerminal = (): Terminal => {
+  const terminal = useMemo(() => {
+    return new Terminal({
+      fontFamily: codeFontFamily,
+      fontSize: defaultCodeFontSizePt * ptToPixelRatio,
+      letterSpacing: 1.1,
+      screenReaderMode: true,
+      theme: {
+        background: backgroundColorTerm,
+      },
+    });
+  }, []);
+
+  const device = useDevice();
+  const isUnmounted = useIsUnmounted();
+  const [, setSelection] = useSelection();
+  useEffect(() => {
+    const tracebackLinkHandler = (e: MouseEvent, traceLine: string) => {
+      const { file, line } = parseTraceLine(traceLine);
+      if (file) {
+        setSelection({ file, location: { line } });
+      }
+    };
+
+    // Group 1 is underlined by xterm.js
+    const tracebackRegExpMatch = /^ {2}(File "[^"]+", line \d+)/;
+    terminal.registerLinkProvider(
+      new WebLinkProvider(
+        terminal,
+        tracebackRegExpMatch,
+        tracebackLinkHandler,
+        {}
+      )
+    );
+    const fitAddon = new FitAddon();
+    terminal.loadAddon(fitAddon);
+    terminal.attachCustomKeyEventHandler(customKeyEventHandler);
+
+    const serialListener = (data: string) => {
+      if (!isUnmounted()) {
+        terminal.write(data);
+      }
+    };
+    const resetListener = () => {
+      if (!isUnmounted()) {
+        terminal.reset();
+      }
+    };
+    device.on(EVENT_SERIAL_DATA, serialListener);
+    device.on(EVENT_SERIAL_RESET, resetListener);
+    terminal.onData((data: string) => {
+      if (!isUnmounted()) {
+        // Async for internal error handling, we don't need to wait.
+        device.serialWrite(data);
+      }
+    });
+
+    // Watch for resize and change terminal rows/cols accordingly.
+    // This can result in a slither of space at the bottom, so backgrounds
+    // should match.
+    const resizeObserver = new ResizeObserver((entries) => {
+      if (!Array.isArray(entries) || !entries.length) {
+        return;
+      }
+      try {
+        fitAddon.fit();
+      } catch (e) {
+        // It throws if you resize it when not visible but it does no harm.
+      }
+    });
+    const terminalOpen = terminal.open.bind(terminal);
+    terminal.open = (parent: HTMLElement) => {
+      terminalOpen(parent);
+      resizeObserver.observe(parent);
+    };
+    return () => {
+      device.removeListener(EVENT_SERIAL_RESET, resetListener);
+      device.removeListener(EVENT_SERIAL_DATA, serialListener);
+      resizeObserver.disconnect();
+      terminal.dispose();
+    };
+  }, [device, setSelection, isUnmounted, terminal]);
+
+  return terminal;
+};
+
+const InternalTerminalContext = React.createContext<undefined | Terminal>(
+  undefined
+);
+
+export const TerminalContext = ({ children }: { children: ReactNode }) => {
+  const terminal = useNewTerminal();
+  return (
+    <InternalTerminalContext.Provider value={terminal}>
+      {children}
+    </InternalTerminalContext.Provider>
+  );
+};
+
+/**
+ * Hook to access the termimal from UI code.
+ *
+ * Prefer {@link #useSerialActions}.
+ *
+ * @returns The terminal.
+ */
+export const useTerminal = () => {
+  const device = useContext(InternalTerminalContext);
+  if (!device) {
+    throw new Error("Missing provider.");
+  }
+  return device;
+};

--- a/src/serial/xterm-custom.css
+++ b/src/serial/xterm-custom.css
@@ -1,3 +1,8 @@
+/**
+ * (c) 2021, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
 .xterm-viewport::-webkit-scrollbar {
   background-color: #333333;
 }

--- a/src/serial/xterm-keyboard.ts
+++ b/src/serial/xterm-keyboard.ts
@@ -1,3 +1,8 @@
+/**
+ * (c) 2021, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
 const copyShortcut = (e: KeyboardEvent): boolean => {
   if (e.ctrlKey && e.shiftKey && e.code === "KeyC") {
     e.preventDefault();

--- a/src/workbench/AboutDialog/AboutDialog.tsx
+++ b/src/workbench/AboutDialog/AboutDialog.tsx
@@ -5,7 +5,6 @@
  */
 import { Button } from "@chakra-ui/button";
 import { useClipboard } from "@chakra-ui/hooks";
-import { ChevronDownIcon, ChevronUpIcon } from "@chakra-ui/icons";
 import { Image } from "@chakra-ui/image";
 import {
   Box,
@@ -37,16 +36,16 @@ import {
   useDisclosure,
   VisuallyHidden,
 } from "@chakra-ui/react";
+import { ReactNode } from "react";
 import { RiFileCopy2Line, RiGithubFill } from "react-icons/ri";
+import { FormattedMessage, useIntl } from "react-intl";
+import ExpandCollapseIcon from "../../common/ExpandCollapseIcon";
 import { useDeployment } from "../../deployment";
-import { FormattedMessage } from "react-intl";
 import { microPythonVersions } from "../../fs/micropython";
 import comicImage from "./comic.png";
 import microbitHeartImage from "./microbit-heart.png";
 import micropythonLogo from "./micropython.jpeg";
 import pythonPoweredLogo from "./python-powered.png";
-import { ReactNode } from "react";
-import { useIntl } from "react-intl";
 
 const versionInfo = [
   {
@@ -213,11 +212,7 @@ const AboutDialog = ({ isOpen, onClose }: AboutDialogProps) => {
                   fontSize="lg"
                   fontWeight="normal"
                   rightIcon={
-                    micropythonSection.isOpen ? (
-                      <ChevronUpIcon />
-                    ) : (
-                      <ChevronDownIcon />
-                    )
+                    <ExpandCollapseIcon open={micropythonSection.isOpen} />
                   }
                   onClick={micropythonSection.onToggle}
                 >

--- a/src/workbench/use-selection.tsx
+++ b/src/workbench/use-selection.tsx
@@ -13,8 +13,30 @@ import React, {
 
 import { MAIN_FILE } from "../fs/fs";
 const Selection = React.createContext<
-  [string, Dispatch<SetStateAction<string>>] | undefined
+  [WorkbenchSelection, Dispatch<SetStateAction<WorkbenchSelection>>] | undefined
 >(undefined);
+
+/**
+ * The workbench selection.
+ */
+export interface WorkbenchSelection {
+  /**
+   * Always defined as we don't let the user delete the main file and default
+   * to having it open.
+   */
+  file: string;
+
+  /**
+   * The line to display when first opening the file.
+   *
+   * Identity changes when the user performs a navigation.
+   */
+  location: FileLocation;
+}
+
+export interface FileLocation {
+  line: number | undefined;
+}
 
 /**
  * Hook exposing the context selection.
@@ -28,6 +50,9 @@ export const useSelection = () => {
 };
 
 export const SelectionContext = ({ children }: { children: ReactNode }) => {
-  const state = useState(MAIN_FILE);
+  const state = useState<WorkbenchSelection>({
+    file: MAIN_FILE,
+    location: { line: undefined },
+  });
   return <Selection.Provider value={state}>{children}</Selection.Provider>;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,7 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
- Add serial utility features from V2 for Ctrl-D, Ctrl-C. 
- Add some minimal in-app help to explain what's going on.

We've stayed away from inline presentation of errors in the editor as runtime errors naturally get out of sync with the current code and we feel it'll be more confusing then helpful. Work is planned for lint errors that will be shown inline as they'll be up-to-date.

There's little by way of e2e testing here. I've made a start on #226 as we'll want to mock the serial interactions.
I really want to cover the line/file navigation.