### PR TITLE
Add docs for autocomplete suggestions (behind a feature flag)

### DIFF
--- a/src/editor/codemirror/language-server/autocompletion.ts
+++ b/src/editor/codemirror/language-server/autocompletion.ts
@@ -22,7 +22,6 @@ import { LanguageServerClient } from "../../../language-server/client";
 import { clientFacet, uriFacet } from "./common";
 import { formatDocumentation } from "./documentation";
 import { offsetToPosition } from "./positions";
-import { languageServer } from "./view";
 
 // Used to find the true start of the completion. Doesn't need to exactly match
 // any language's identifier definition.

--- a/src/editor/codemirror/language-server/autocompletion.ts
+++ b/src/editor/codemirror/language-server/autocompletion.ts
@@ -77,7 +77,7 @@ export const autocompletion = () =>
                   label: item.label,
                   type: item.kind ? mapCompletionKind[item.kind] : undefined,
                   detail: item.detail,
-                  info: mapDocumentation(item.documentation),
+                  info: resolveDocumentation,
                   sortText: item.sortText ?? item.label,
                   boost: boost(item),
                 };
@@ -90,6 +90,12 @@ export const autocompletion = () =>
     ],
   });
 
+const resolveDocumentation = async (completion: Completion): Promise<Node> => {
+  const div = document.createElement("div");
+  div.innerText = "No docs for " + completion.label;
+  return div;
+};
+
 const createTriggerCharactersRegExp = (
   client: LanguageServerClient
 ): RegExp | undefined => {
@@ -98,17 +104,6 @@ const createTriggerCharactersRegExp = (
     return new RegExp("[" + escapeRegex(characters.join("")) + "]");
   }
   return undefined;
-};
-
-const mapDocumentation = (
-  documentation: string | LSP.MarkupContent | undefined
-): undefined | string => {
-  // We should be able to resolve documentation here by calling into the client again
-  // and returning a function.
-  if (typeof documentation === "object") {
-    return documentation.value;
-  }
-  return documentation;
 };
 
 const mapCompletionKind = Object.fromEntries(

--- a/src/editor/codemirror/language-server/documentation.ts
+++ b/src/editor/codemirror/language-server/documentation.ts
@@ -1,0 +1,9 @@
+import { MarkupContent } from "vscode-languageserver-types";
+
+export const formatDocumentation = (documentation: MarkupContent | string) => {
+  // Obviously inadequate!
+  if (MarkupContent.is(documentation)) {
+    return documentation.value;
+  }
+  return documentation;
+};

--- a/src/editor/codemirror/language-server/signatureHelp.ts
+++ b/src/editor/codemirror/language-server/signatureHelp.ts
@@ -24,6 +24,7 @@ import {
 } from "vscode-languageserver-protocol";
 import { offsetToPosition } from "./positions";
 import { BaseLanguageServerView } from "./common";
+import { formatDocumentation } from "./documentation";
 
 interface SignatureChangeEffect {
   pos: number;
@@ -120,6 +121,7 @@ const reduceSignatureHelpState = (
       tooltip: {
         pos: effect.pos,
         above: true,
+        // This isn't great but the impact is really bad when it conflicts with autocomplete.
         strictSide: true,
         create: () => {
           const dom = document.createElement("div");
@@ -135,13 +137,7 @@ const reduceSignatureHelpState = (
 
 const formatSignatureHelp = (result: SignatureHelp): string => {
   const { documentation, label } = result.signatures[result.activeSignature!];
-  if (documentation) {
-    if (MarkupContent.is(documentation)) {
-      return documentation.value;
-    }
-    return documentation;
-  }
-  return label;
+  return documentation ? formatDocumentation(documentation) : label;
 };
 
 const signatureHelpToolTipBaseTheme = EditorView.baseTheme({

--- a/src/editor/codemirror/language-server/signatureHelp.ts
+++ b/src/editor/codemirror/language-server/signatureHelp.ts
@@ -7,8 +7,8 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { Tooltip, showTooltip } from "@codemirror/tooltip";
 import { StateEffect, StateField, Text } from "@codemirror/state";
+import { showTooltip, Tooltip } from "@codemirror/tooltip";
 import {
   EditorView,
   logException,
@@ -20,11 +20,10 @@ import {
   SignatureHelp,
   SignatureHelpParams,
   SignatureHelpRequest,
-  MarkupContent,
 } from "vscode-languageserver-protocol";
-import { offsetToPosition } from "./positions";
 import { BaseLanguageServerView } from "./common";
 import { formatDocumentation } from "./documentation";
+import { offsetToPosition } from "./positions";
 
 interface SignatureChangeEffect {
   pos: number;

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -14,6 +14,7 @@ import { stage } from "./environment";
 
 interface Flags {
   signatureHelp: boolean;
+  autocompleteDocs: boolean;
 }
 
 const isPreviewStage = () => !(stage === "STAGING" || stage === "PRODUCTION");
@@ -21,5 +22,9 @@ const isPreviewStage = () => !(stage === "STAGING" || stage === "PRODUCTION");
 export const flags: Flags = isPreviewStage()
   ? {
       signatureHelp: true,
+      autocompleteDocs: true,
     }
-  : { signatureHelp: false };
+  : {
+      signatureHelp: false,
+      autocompleteDocs: false,
+    };


### PR DESCRIPTION
The content of the documentation isn't quite right for us, but that'll need to be fixed on the Pyright end (probably) or with an alternative source of info. It's returned as a string or markup content so it's not just a matter of presenting it differently in our app.

I think this is worth merging behind a flag so we can see what we get from just glue code between CM and Pyright.