### PR TITLE
Consistent naming of app-level context providers.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,26 +11,26 @@ import { useLocalStorage } from "./common/use-local-storage";
 import VisualViewPortCSSVariables from "./common/VisualViewportCSSVariables";
 import { deployment, useDeployment } from "./deployment";
 import { MicrobitWebUSBConnection } from "./device/device";
-import { DeviceContext } from "./device/device-hooks";
+import { DeviceContextProvider } from "./device/device-hooks";
 import { MockDeviceConnection } from "./device/mock";
 import { FileSystem } from "./fs/fs";
-import { FileSystemContext } from "./fs/fs-hooks";
+import { FileSystemProvider } from "./fs/fs-hooks";
 import { createInitialProject } from "./fs/initial-project";
 import { fetchMicroPython } from "./fs/micropython";
 import { trackFsChanges } from "./language-server/client-fs";
-import { LanguageServerClientContext } from "./language-server/language-server-hooks";
+import { LanguageServerClientProvider } from "./language-server/language-server-hooks";
 import { pyright } from "./language-server/pyright";
-import { LoggingContext } from "./logging/logging-hooks";
+import { LoggingProvider } from "./logging/logging-hooks";
 import TranslationProvider from "./messages/TranslationProvider";
 import ProjectDropTarget from "./project/ProjectDropTarget";
 import {
   defaultSettings,
   isValidSettingsObject,
   Settings,
-  SettingsContext,
+  SettingsProvider,
 } from "./settings/settings";
 import BeforeUnloadDirtyCheck from "./workbench/BeforeUnloadDirtyCheck";
-import { SelectionContext } from "./workbench/use-selection";
+import { SelectionProvider } from "./workbench/use-selection";
 import Workbench from "./workbench/Workbench";
 
 const isMockDeviceMode = () =>
@@ -75,26 +75,26 @@ const App = () => {
     <>
       <VisualViewPortCSSVariables />
       <ChakraProvider theme={deployment.chakraTheme}>
-        <LoggingContext.Provider value={logging}>
-          <SettingsContext.Provider value={settings}>
+        <LoggingProvider value={logging}>
+          <SettingsProvider value={settings}>
             <TranslationProvider>
               <DialogProvider>
-                <DeviceContext.Provider value={device}>
-                  <FileSystemContext.Provider value={fs}>
-                    <LanguageServerClientContext.Provider value={client}>
+                <DeviceContextProvider value={device}>
+                  <FileSystemProvider value={fs}>
+                    <LanguageServerClientProvider value={client}>
                       <BeforeUnloadDirtyCheck />
-                      <SelectionContext>
+                      <SelectionProvider>
                         <ProjectDropTarget>
                           <Workbench />
                         </ProjectDropTarget>
-                      </SelectionContext>
-                    </LanguageServerClientContext.Provider>
-                  </FileSystemContext.Provider>
-                </DeviceContext.Provider>
+                      </SelectionProvider>
+                    </LanguageServerClientProvider>
+                  </FileSystemProvider>
+                </DeviceContextProvider>
               </DialogProvider>
             </TranslationProvider>
-          </SettingsContext.Provider>
-        </LoggingContext.Provider>
+          </SettingsProvider>
+        </LoggingProvider>
       </ChakraProvider>
     </>
   );

--- a/src/device/device-hooks.ts
+++ b/src/device/device-hooks.ts
@@ -13,9 +13,11 @@ import {
   EVENT_SERIAL_ERROR,
 } from "./device";
 
-export const DeviceContext = React.createContext<undefined | DeviceConnection>(
+const DeviceContext = React.createContext<undefined | DeviceConnection>(
   undefined
 );
+
+export const DeviceContextProvider = DeviceContext.Provider;
 
 /**
  * Hook to access the device from UI code.

--- a/src/fs/fs-hooks.ts
+++ b/src/fs/fs-hooks.ts
@@ -6,9 +6,9 @@
 import { createContext, useContext } from "react";
 import { FileSystem } from "./fs";
 
-export const FileSystemContext = createContext<FileSystem | undefined>(
-  undefined
-);
+const FileSystemContext = createContext<FileSystem | undefined>(undefined);
+
+export const FileSystemProvider = FileSystemContext.Provider;
 
 /**
  * Hook exposing the file system.

--- a/src/language-server/language-server-hooks.ts
+++ b/src/language-server/language-server-hooks.ts
@@ -6,9 +6,12 @@
 import { createContext, useContext } from "react";
 import { LanguageServerClient } from "./client";
 
-export const LanguageServerClientContext = createContext<
+const LanguageServerClientContext = createContext<
   LanguageServerClient | undefined
 >(undefined);
+
+export const LanguageServerClientProvider =
+  LanguageServerClientContext.Provider;
 
 export const useLanguageServerClient = (): LanguageServerClient | undefined => {
   // It can be undefined if not supported (e.g. in Jest).

--- a/src/logging/logging-hooks.ts
+++ b/src/logging/logging-hooks.ts
@@ -6,7 +6,9 @@
 import { createContext, useContext } from "react";
 import { Logging } from "./logging";
 
-export const LoggingContext = createContext<Logging | undefined>(undefined);
+const LoggingContext = createContext<Logging | undefined>(undefined);
+
+export const LoggingProvider = LoggingContext.Provider;
 
 /**
  * Hook exposing logging.

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -103,9 +103,11 @@ export interface Settings {
 
 type SettingsContextValue = [Settings, (settings: Settings) => void];
 
-export const SettingsContext = createContext<SettingsContextValue | undefined>(
+const SettingsContext = createContext<SettingsContextValue | undefined>(
   undefined
 );
+
+export const SettingsProvider = SettingsContext.Provider;
 
 export const useSettings = (): SettingsContextValue => {
   const settings = useContext(SettingsContext);

--- a/src/workbench/use-selection.tsx
+++ b/src/workbench/use-selection.tsx
@@ -49,7 +49,7 @@ export const useSelection = () => {
   return value;
 };
 
-export const SelectionContext = ({ children }: { children: ReactNode }) => {
+export const SelectionProvider = ({ children }: { children: ReactNode }) => {
   const state = useState<WorkbenchSelection>({
     file: MAIN_FILE,
     location: { line: undefined },


### PR DESCRIPTION
Match the naming used by Chakra of FooProvider and don't expose the
context directly.