### PR TITLE
Documentation links for autocomplete and signature help

### DIFF
--- a/src/editor/codemirror/language-server/autocompletion.ts
+++ b/src/editor/codemirror/language-server/autocompletion.ts
@@ -21,8 +21,11 @@ import {
 } from "vscode-languageserver-protocol";
 import { LanguageServerClient } from "../../../language-server/client";
 import { clientFacet, uriFacet } from "./common";
-import { renderDocumentation } from "./documentation";
-import { removeFullyQualifiedName } from "./names";
+import {
+  renderDocumentation,
+  wrapWithDocumentationButton,
+} from "./documentation";
+import { nameFromSignature, removeFullyQualifiedName } from "./names";
 import { offsetToPosition } from "./positions";
 import { escapeRegExp } from "./regexp-util";
 
@@ -126,7 +129,9 @@ const createDocumentationResolver =
     const node = renderDocumentation(resolved.documentation, true);
     const code = node.querySelector("code");
     if (code) {
+      const id = nameFromSignature(code.innerText);
       code.innerText = removeFullyQualifiedName(code.innerText);
+      return wrapWithDocumentationButton(node, id);
     }
     return node;
   };

--- a/src/editor/codemirror/language-server/documentation.ts
+++ b/src/editor/codemirror/language-server/documentation.ts
@@ -80,3 +80,37 @@ export const renderMarkdown = (
     __html: html,
   };
 };
+
+export const wrapWithDocumentationButton = (child: Element, id: string) => {
+  const wrapper = document.createElement("div");
+  wrapper.style.display = "flex";
+  wrapper.style.height = "100%";
+  wrapper.style.flexDirection = "column";
+  wrapper.style.justifyContent = "space-between";
+  wrapper.appendChild(child);
+
+  const button = child.appendChild(document.createElement("button"));
+  button.innerHTML =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="1rem" height="1rem"><path fill="none" d="M0 0h24v24H0z"/><path d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10-4.477 10-10 10zm0-2a8 8 0 1 0 0-16 8 8 0 0 0 0 16zM11 7h2v2h-2V7zm0 4h2v6h-2v-6z"/></svg>';
+  button.ariaLabel = "More info";
+  button.onclick = () => {
+    document.dispatchEvent(
+      new CustomEvent("cm/openDocs", {
+        detail: {
+          id,
+        },
+      })
+    );
+  };
+  button.style.marginTop = "auto";
+  button.style.display = "block";
+  button.style.float = "right";
+  button.style.margin = "0";
+  button.style.paddingTop = "0.5rem";
+  button.style.paddingBottom = "0.5rem";
+  button.style.alignSelf = "flex-end";
+
+  wrapper.appendChild(button);
+
+  return wrapper;
+};

--- a/src/editor/codemirror/language-server/names.ts
+++ b/src/editor/codemirror/language-server/names.ts
@@ -13,3 +13,9 @@ export const removeFullyQualifiedName = (fn: string): string => {
   const name = parts[parts.length - 1];
   return name + remainder;
 };
+
+export const nameFromSignature = (fn: string): string => {
+  const bracket = fn.indexOf("(");
+  const before = fn.substring(0, bracket);
+  return before;
+};

--- a/src/editor/codemirror/language-server/signatureHelp.ts
+++ b/src/editor/codemirror/language-server/signatureHelp.ts
@@ -23,8 +23,11 @@ import {
   SignatureHelpRequest,
 } from "vscode-languageserver-protocol";
 import { BaseLanguageServerView } from "./common";
-import { renderDocumentation } from "./documentation";
-import { removeFullyQualifiedName } from "./names";
+import {
+  wrapWithDocumentationButton,
+  renderDocumentation,
+} from "./documentation";
+import { nameFromSignature, removeFullyQualifiedName } from "./names";
 import { offsetToPosition } from "./positions";
 
 interface SignatureChangeEffect {
@@ -179,6 +182,7 @@ const formatHighlightedParameter = (
   activeParameterDoc: string | MarkupContent | undefined
 ): Node => {
   let before = label.substring(0, from);
+  const id = nameFromSignature(before);
   const parameter = label.substring(from, to);
   const after = label.substring(to);
 
@@ -197,7 +201,7 @@ const formatHighlightedParameter = (
   const documentation = renderDocumentation(activeParameterDoc);
   parent.appendChild(documentation);
 
-  return parent;
+  return wrapWithDocumentationButton(parent, id);
 };
 
 const signatureHelpToolTipBaseTheme = EditorView.baseTheme({


### PR DESCRIPTION
The scrolling is awkward and doesn't play nice with the fixed accordion
header. We may well be changing that as part of design work.

TODO:
- [ ] Focus Advanced tab.
- [ ] Scrolling issue
    - Wait for / block on design changes that might avoid scrolling entirely?
- [ ] Less messy communication channel? Not clear how best to glue CM and React state together here.
- [ ] Hide when advanced docs not enabled (use flag).
- [ ] Translation in CM code (just "More info" or similar for now).
