### PR TITLE
Generalise import handling to work with Python code

### DIFF
--- a/src/editor/codemirror/edits.test.ts
+++ b/src/editor/codemirror/edits.test.ts
@@ -1,35 +1,24 @@
 import { EditorState } from "@codemirror/state";
 import { python } from "@codemirror/lang-python";
-import { calculateImportChanges, RequiredImport } from "./edits";
+import { calculateChanges } from "./edits";
 import { EditorView } from "@codemirror/view";
 
 describe("edits", () => {
-  const check = (
-    initial: string,
-    requiredImport: RequiredImport,
-    expected: string
-  ) => {
+  const check = (initial: string, additional: string, expected: string) => {
     const state = EditorState.create({
       doc: initial,
       extensions: [python()],
     });
     const view = new EditorView({ state });
     const transaction = state.update({
-      changes: calculateImportChanges(state, requiredImport),
+      changes: calculateChanges(state, additional),
     });
     view.update([transaction]);
     expect(view.state.sliceDoc(0)).toEqual(expected);
   };
 
   it("first import from case - wildcard", () => {
-    check(
-      "",
-      {
-        module: "microbit",
-        name: "*",
-      },
-      "from microbit import *\n\n"
-    );
+    check("", "from microbit import *", "from microbit import *\n\n");
   });
 
   it("first import from case - name", () => {
@@ -126,5 +115,15 @@ describe("edits", () => {
       },
       "from random import randrange\n\nimport\nfrom\n"
     );
+  });
+});
+
+describe("smoosh", () => {
+  it("works", () => {
+    const state = EditorState.create({
+      doc: "",
+      extensions: [python()],
+    });
+    smoosh(state, "import radio\n\nradio.on()\n");
   });
 });

--- a/src/editor/codemirror/edits.test.ts
+++ b/src/editor/codemirror/edits.test.ts
@@ -24,40 +24,23 @@ describe("edits", () => {
   it("first import from case - name", () => {
     check(
       "",
-      {
-        module: "random",
-        name: "randrange",
-      },
+      "from random import randrange",
       "from random import randrange\n\n"
     );
   });
 
   it("first import module case", () => {
-    check(
-      "",
-      {
-        module: "audio",
-      },
-      "import audio\n\n"
-    );
+    check("", "import audio", "import audio\n\n");
   });
 
   it("existing import module case", () => {
-    check(
-      "import audio",
-      {
-        module: "audio",
-      },
-      "import audio"
-    );
+    check("import audio", "import audio", "import audio");
   });
 
   it("existing import module case - as variant", () => {
     check(
       "import audio as foo",
-      {
-        module: "audio",
-      },
+      "import audio",
       "import audio as foo\nimport audio"
     );
   });
@@ -65,10 +48,7 @@ describe("edits", () => {
   it("existing import from case - wildcard", () => {
     check(
       "from microbit import *",
-      {
-        module: "microbit",
-        name: "*",
-      },
+      "from microbit import *",
       "from microbit import *"
     );
   });
@@ -76,10 +56,7 @@ describe("edits", () => {
   it("existing import from case - name", () => {
     check(
       "from random import randrange",
-      {
-        module: "random",
-        name: "randrange",
-      },
+      "from random import randrange",
       "from random import randrange"
     );
   });
@@ -87,10 +64,7 @@ describe("edits", () => {
   it("existing import from case - alias", () => {
     check(
       "from random import randrange as foo",
-      {
-        module: "random",
-        name: "randrange",
-      },
+      "from random import randrange",
       "from random import randrange as foo, randrange"
     );
   });
@@ -98,10 +72,7 @@ describe("edits", () => {
   it("existing from import new name", () => {
     check(
       "from random import getrandbits",
-      {
-        module: "random",
-        name: "randrange",
-      },
+      "from random import randrange",
       "from random import getrandbits, randrange"
     );
   });
@@ -109,21 +80,8 @@ describe("edits", () => {
   it("copes with invalid imports", () => {
     check(
       "import\nfrom\n",
-      {
-        module: "random",
-        name: "randrange",
-      },
+      "from random import randrange",
       "from random import randrange\n\nimport\nfrom\n"
     );
-  });
-});
-
-describe("smoosh", () => {
-  it("works", () => {
-    const state = EditorState.create({
-      doc: "",
-      extensions: [python()],
-    });
-    smoosh(state, "import radio\n\nradio.on()\n");
   });
 });

--- a/src/editor/codemirror/edits.ts
+++ b/src/editor/codemirror/edits.ts
@@ -120,7 +120,7 @@ export const calculateChanges = (state: EditorState, addition: string) => {
   const requiredImports: RequiredImport[] = additionalImports.flatMap(
     (additionalImport) => {
       if (additionalImport.kind === "from") {
-        (additionalImport.names ?? []).map((name) => {
+        return (additionalImport.names ?? []).map((name) => {
           if (name.alias) {
             throw new AliasesNotSupportedError();
           }


### PR DESCRIPTION
Generalise import handling to work with Python code specifying the imports rather than a restrictive JSON model of the imports. This way we're closer to being able to add arbitrary Python snippets to existing code respecting their imports.