### PR TITLE
Use code font for all code text in Advanced toolkit.

### DIFF
--- a/src/documentation/AdvancedTooklit.tsx
+++ b/src/documentation/AdvancedTooklit.tsx
@@ -64,6 +64,7 @@ const ActiveTooklitLevel = ({
           heading={
             <ToolkitBreadcrumbHeading
               parent={"Advanced"}
+              titleFontFamily="code"
               title={item.name}
               onBack={() => onNavigate(undefined)}
             />
@@ -93,6 +94,8 @@ const ActiveTooklitLevel = ({
               parent={moduleName}
               grandparent={"Advanced"}
               title={item.name}
+              titleFontFamily="code"
+              parentFontFamily="code"
               onBack={() => onNavigate(moduleName)}
             />
           }

--- a/src/documentation/AdvancedTooklit.tsx
+++ b/src/documentation/AdvancedTooklit.tsx
@@ -120,6 +120,7 @@ const ActiveTooklitLevel = ({
           <ToolkitTopLevelListItem
             key={module.id}
             name={module.fullName}
+            headingFontFamily="code"
             description={
               module.docString && <DocString value={module.docString} />
             }

--- a/src/documentation/ToolkitDocumentation/ToolkitBreadcrumbHeading.tsx
+++ b/src/documentation/ToolkitDocumentation/ToolkitBreadcrumbHeading.tsx
@@ -12,6 +12,8 @@ interface BreadcrumbHeadingProps {
   parent: string;
   grandparent?: string;
   onBack: () => void;
+  titleFontFamily?: "code";
+  parentFontFamily?: "code";
 }
 
 const ToolkitBreadcrumbHeading = ({
@@ -19,6 +21,8 @@ const ToolkitBreadcrumbHeading = ({
   parent,
   grandparent,
   onBack,
+  parentFontFamily,
+  titleFontFamily,
 }: BreadcrumbHeadingProps) => {
   return (
     <Stack spacing={0} position="sticky">
@@ -40,11 +44,20 @@ const ToolkitBreadcrumbHeading = ({
           alignItems="center"
           fontWeight="sm"
         >
-          {grandparent && grandparent + " / "}
-          {parent}
+          <Text as="span">
+            {grandparent && grandparent + " / "}
+            <Text as="span" fontFamily={parentFontFamily}>
+              {parent}
+            </Text>
+          </Text>
         </Button>
       </HStack>
-      <Text as="h2" fontSize="3xl" fontWeight="semibold">
+      <Text
+        as="h2"
+        fontSize="3xl"
+        fontWeight="semibold"
+        fontFamily={titleFontFamily}
+      >
         {title}
       </Text>
     </Stack>

--- a/src/documentation/ToolkitDocumentation/ToolkitTopLevelListItem.tsx
+++ b/src/documentation/ToolkitDocumentation/ToolkitTopLevelListItem.tsx
@@ -8,16 +8,23 @@ interface ToolkitTopLevelListItemProps {
   name: string;
   description: ReactNode;
   onForward: () => void;
+  headingFontFamily?: "code";
 }
 
 const ToolkitTopLevelListItem = ({
   name,
   description,
   onForward,
+  headingFontFamily,
 }: ToolkitTopLevelListItemProps) => (
   <ToolkitListItem onClick={onForward} cursor="pointer">
     <Box flex="1 1 auto">
-      <Text as="h3" fontSize="lg" fontWeight="semibold">
+      <Text
+        as="h3"
+        fontFamily={headingFontFamily}
+        fontSize="lg"
+        fontWeight="semibold"
+      >
         {name}
       </Text>
       {/*Content problem! We need all descriptions to be short, or two sets.*/}

--- a/src/e2e/app.ts
+++ b/src/e2e/app.ts
@@ -413,10 +413,28 @@ export class App {
     }, defaultWaitForOptions);
   }
 
-  async findToolkitHeading(context: string, title: string): Promise<void> {
+  async findToolkitBreadcrumbHeading(
+    context: string,
+    title: string
+  ): Promise<void> {
     const document = await this.document();
-    await document.findByText(context);
-    await document.findByText(title, { selector: "h2" });
+    await document.findByRole("button", {
+      name: context,
+    });
+    await document.findByText(title, {
+      selector: "h2",
+    });
+  }
+
+  async findToolkitTopLevelHeading(
+    title: string,
+    description: string
+  ): Promise<void> {
+    const document = await this.document();
+    await document.findByText(title, {
+      selector: "h2",
+    });
+    await document.findByText(description);
   }
 
   /**

--- a/src/e2e/autocomplete.test.ts
+++ b/src/e2e/autocomplete.test.ts
@@ -37,7 +37,10 @@ describe("Browser - autocomplete and signature help tests", () => {
 
     await app.followCompletionOrSignatureAdvancedLink();
 
-    await app.findToolkitHeading("Advanced / microbit.display", "show");
+    await app.findToolkitBreadcrumbHeading(
+      "Advanced / microbit.display",
+      "show"
+    );
   });
 
   it("shows signature help after autocomplete", async () => {
@@ -57,6 +60,9 @@ describe("Browser - autocomplete and signature help tests", () => {
 
     await app.followCompletionOrSignatureAdvancedLink();
 
-    await app.findToolkitHeading("Advanced / microbit.display", "show");
+    await app.findToolkitBreadcrumbHeading(
+      "Advanced / microbit.display",
+      "show"
+    );
   });
 });

--- a/src/e2e/toolkit.test.ts
+++ b/src/e2e/toolkit.test.ts
@@ -14,9 +14,9 @@ describe("Browser - toolkit tabs", () => {
 
   it("Advanced toolkit navigation", async () => {
     await app.switchTab("Advanced");
-    await app.findToolkitHeading(
-      "Reference documentation for micro:bit MicroPython",
-      "Advanced"
+    await app.findToolkitTopLevelHeading(
+      "Advanced",
+      "Reference documentation for micro:bit MicroPython"
     );
   });
 


### PR DESCRIPTION
I'm unsure about the breadcrumb, the visual contrast isn't helpful.