### PR TITLE
Improve fidelity of toolkit mocks

### DIFF
--- a/src/documentation/ToolkitDocumentation/TopicItem.tsx
+++ b/src/documentation/ToolkitDocumentation/TopicItem.tsx
@@ -42,12 +42,58 @@ const TopicItem = ({
   item,
   detail,
   onForward,
+
   ...props
 }: TopicItemProps) => {
+  const contents = detail
+    ? item.contents
+    : item.contents.filter((x) => !x.detail);
+  return (
+    <Stack spacing={3} {...props} fontSize="sm">
+      <Text as="h3" fontSize="lg" fontWeight="semibold">
+        {item.name}
+      </Text>
+      {contents.map((block, index) => {
+        // CMS will have _key here.
+        // We can also support paragraphs, formatting etc. properly.
+        switch (block._type) {
+          case "code":
+            return (
+              <CodeTemplate
+                key={index}
+                toolkitCode={block}
+                detail={detail}
+                hasDetail={contents.length !== item.contents.length}
+                onForward={onForward}
+              />
+            );
+          case "text":
+            return <Text key={index}>{block.value}</Text>;
+          default:
+            throw new Error();
+        }
+      })}
+    </Stack>
+  );
+};
+
+interface CodeTemplateProps {
+  toolkitCode: ToolkitCode;
+  detail?: boolean;
+  hasDetail?: boolean;
+  onForward: () => void;
+}
+
+const CodeTemplate = ({
+  detail,
+  hasDetail,
+  onForward,
+  toolkitCode,
+}: CodeTemplateProps) => {
   const actions = useActiveEditorActions();
   const [hovering, setHovering] = useState(false);
   const [option, setOption] = useState<string | undefined>(
-    item.code.select?.options[0]
+    toolkitCode.select?.options[0]
   );
   const handleSelectChange = useCallback(
     (e: ChangeEvent<HTMLSelectElement>) => {
@@ -55,23 +101,20 @@ const TopicItem = ({
     },
     [setOption]
   );
-  const templatedCode = templateCode(item.code, option);
+  const templatedCode = templateCode(toolkitCode, option);
   // Strip the imports.
   const code = templatedCode.replace(/^\s*(from[ ]|import[ ]).*$/gm, "").trim();
   const codeRef = useRef<HTMLDivElement>(null);
   const lines = code.trim().split("\n").length;
   const textHeight = lines * 1.5 + "em";
   const codeHeight = `calc(${textHeight} + var(--chakra-space-5) + var(--chakra-space-5))`;
+
   return (
-    <Stack spacing={3} {...props} fontSize="sm">
-      <Text as="h3" fontSize="lg" fontWeight="semibold">
-        {item.name}
-      </Text>
-      <Text>{item.text}</Text>
-      {item.code.select && (
+    <>
+      {toolkitCode.select && (
         <Flex wrap="wrap" as="label">
           <Text alignSelf="center" mr={2} as="span">
-            {item.code.select.prompt}
+            {toolkitCode.select.prompt}
           </Text>
           <Select
             w="fit-content"
@@ -79,7 +122,7 @@ const TopicItem = ({
             value={option}
             size="sm"
           >
-            {item.code.select.options.map((option) => (
+            {toolkitCode.select.options.map((option) => (
               <option key={option} value={option}>
                 {option}
               </option>
@@ -120,11 +163,10 @@ const TopicItem = ({
           >
             Insert code
           </Button>
-          {!detail && item.furtherText && <MoreButton onClick={onForward} />}
+          {!detail && hasDetail && <MoreButton onClick={onForward} />}
         </HStack>
       </Box>
-      {detail && <Text>{item.furtherText}</Text>}
-    </Stack>
+    </>
   );
 };
 

--- a/src/documentation/ToolkitDocumentation/TopicItem.tsx
+++ b/src/documentation/ToolkitDocumentation/TopicItem.tsx
@@ -49,10 +49,12 @@ const TopicItem = ({
     ? item.contents
     : item.contents.filter((x) => !x.detail);
   return (
-    <Stack spacing={3} {...props} fontSize="sm">
-      <Text as="h3" fontSize="lg" fontWeight="semibold">
-        {item.name}
-      </Text>
+    <Stack spacing={detail ? 5 : 3} {...props} fontSize={detail ? "md" : "sm"}>
+      {!detail && (
+        <Text as="h3" fontSize="lg" fontWeight="semibold">
+          {item.name}
+        </Text>
+      )}
       {contents.map((block, index) => {
         // CMS will have _key here.
         // We can also support paragraphs, formatting etc. properly.

--- a/src/documentation/ToolkitDocumentation/model.ts
+++ b/src/documentation/ToolkitDocumentation/model.ts
@@ -24,6 +24,8 @@ export interface ToolkitTopic {
 }
 
 export interface ToolkitCode {
+  _type: "code";
+  detail?: boolean;
   value: string;
   select?: {
     prompt: string;
@@ -32,11 +34,15 @@ export interface ToolkitCode {
   };
 }
 
+export interface ToolkitText {
+  _type: "text";
+  detail?: boolean;
+  value: string;
+}
+
 export interface ToolkitTopicItem {
   name: string;
-  text: string;
-  code: ToolkitCode;
-  furtherText?: string;
+  contents: Array<ToolkitCode | ToolkitText>;
 }
 
 export interface ToolkitNavigationState {

--- a/src/documentation/toolkit-mock-data.ts
+++ b/src/documentation/toolkit-mock-data.ts
@@ -14,22 +14,49 @@ export const microbitToolkit: Toolkit = {
       description: "Use the micro:bit LEDs for text and images",
       contents: [
         {
-          name: "Scrolling words and numbers",
+          name: "Scroll",
           contents: [
             {
               _type: "text",
               value:
-                "You can scroll words and numbers on the micro:bit's LED display:",
+                "You can scroll words and numbers on the micro:bit’s LED display:",
             },
             {
               _type: "code",
               value:
                 "from microbit import *\n\ndisplay.scroll('score')\ndisplay.scroll(23)",
             },
+            {
+              _type: "text",
+              detail: true,
+              value:
+                "Using extra parameters you can control the speed of the scrolling, whether it loops, and if it waits for the scrolling to stop before executing the next instruction.",
+            },
+            {
+              _type: "text",
+              detail: true,
+              value: "Any delay less than 150ms will be faster than normal.",
+            },
+            {
+              _type: "text",
+              detail: true,
+              value:
+                "This code will keep scrolling the word ‘score’ faster than normal in a loop, and play music at the same time:",
+            },
+            {
+              _type: "code",
+              detail: true,
+              value: `
+from microbit import *
+import music
+display.scroll('score', delay=100, loop=True, wait=False) 
+music.play(music.ODE)
+`,
+            },
           ],
         },
         {
-          name: "Show one character at a time",
+          name: "Show",
           contents: [
             {
               _type: "text",
@@ -45,7 +72,25 @@ export const microbitToolkit: Toolkit = {
               _type: "text",
               detail: true,
               value:
-                "Any delay below 400ms will be faster than normal, anything above 400ms slower than normal. This example will keep showing a countdown in a loop with 1 second between each number and will not wait before executing the next instruction: [NO EXAMPLE YET]",
+                "You can use the `delay`, `loop` and `wait` options with display.show.",
+            },
+            {
+              _type: "text",
+              detail: true,
+              value:
+                "Any delay below 400ms will be faster than normal, anything above 400ms slower than normal.",
+            },
+            {
+              _type: "text",
+              detail: true,
+              value:
+                "This example will keep showing a countdown in a loop with 1 second between each number and will not wait before executing the next instruction:",
+            },
+            {
+              _type: "code",
+              detail: true,
+              value: `from microbit import *
+display.show(9876543210, delay=1000, loop=True, wait=False)`,
             },
           ],
         },
@@ -81,6 +126,38 @@ export const microbitToolkit: Toolkit = {
               },
               value: "from microbit import *\n\ndisplay.show(@IMAGE@)",
             },
+            {
+              _type: "text",
+              value:
+                "There are lots more images to choose from. Use the dropdown above to try different images.",
+            },
+            {
+              _type: "text",
+              detail: true,
+              value:
+                "For the full list of built-in images, look here [NO LINK YET]",
+            },
+          ],
+        },
+        {
+          name: "Images: make your own",
+          contents: [
+            {
+              _type: "text",
+              value:
+                "You can make your own pictures like this. Use numbers between 0 and 9. 0 means the LED is off, 9 is the brightest. Can you guess what this will show?",
+            },
+            {
+              _type: "code",
+              value: `from microbit import *
+
+display.show(Image('00300:'
+  '03630:'
+  '36963:'
+  '03630:'
+  '00300'))      
+`,
+            },
           ],
         },
         {
@@ -107,6 +184,28 @@ export const microbitToolkit: Toolkit = {
             {
               _type: "code",
               value: "from microbit import *\ndisplay.set_pixel(0,0,9)",
+            },
+            {
+              _type: "text",
+              detail: true,
+              value:
+                "You can light up individual pixels. Each pixel has a co-ordinate starting at the top left with 0,0. Use numbers 0 to 9 to select how bright you want each pixel to be, with 9 being the brightest. This will light the top left LED as bright as it can go:",
+            },
+            {
+              _type: "code",
+              detail: true,
+              value: `from microbit import *
+
+for y in range(5):
+for x in range(5):
+    display.set_pixel(x,y,9)
+    sleep(50)
+`,
+            },
+            {
+              _type: "text",
+              detail: true,
+              value: "Note that this uses a nested loop, a loop inside a loop.",
             },
           ],
         },

--- a/src/documentation/toolkit-mock-data.ts
+++ b/src/documentation/toolkit-mock-data.ts
@@ -15,60 +15,100 @@ export const microbitToolkit: Toolkit = {
       contents: [
         {
           name: "Scrolling words and numbers",
-          text: "You can scroll words and numbers on the micro:bit's LED display:",
-          code: {
-            value:
-              "from microbit import *\n\ndisplay.scroll('score')\ndisplay.scroll(23)",
-          },
-          // This has a "More", but it's a much richer notion than we have so far.
+          contents: [
+            {
+              _type: "text",
+              value:
+                "You can scroll words and numbers on the micro:bit's LED display:",
+            },
+            {
+              _type: "code",
+              value:
+                "from microbit import *\n\ndisplay.scroll('score')\ndisplay.scroll(23)",
+            },
+          ],
         },
         {
           name: "Show one character at a time",
-          text: "You can show words and numbers on the LED display one character at a time:",
-          code: {
-            value:
-              "from microbit import *\n\ndisplay.show('score')\ndisplay.show(23)",
-          },
-          // TODO: formatting needed for params, extra code etc.
-          furtherText:
-            "Any delay below 400ms will be faster than normal, anything above 400ms slower than normal. This example will keep showing a countdown in a loop with 1 second between each number and will not wait before executing the next instruction: [NO EXAMPLE YET]",
+          contents: [
+            {
+              _type: "text",
+              value:
+                "You can show words and numbers on the LED display one character at a time:",
+            },
+            {
+              _type: "code",
+              value:
+                "from microbit import *\n\ndisplay.show('score')\ndisplay.show(23)",
+            },
+            {
+              _type: "text",
+              detail: true,
+              value:
+                "Any delay below 400ms will be faster than normal, anything above 400ms slower than normal. This example will keep showing a countdown in a loop with 1 second between each number and will not wait before executing the next instruction: [NO EXAMPLE YET]",
+            },
+          ],
         },
         {
           name: "Images: built-in",
-          text: "The micro:bit has lots of built-in pictures that you can show on the display.",
-          code: {
-            select: {
-              prompt: "Show example for:",
-              placeholder: "@IMAGE@",
-              options: [
-                "Image.HEART",
-                "Image.HEART_SMALL",
-                "Image.HAPPY",
-                "Image.SMILE",
-                "Image.SAD",
-                "Image.CONFUSED",
-                "Image.ANGRY",
-                "Image.ASLEEP",
-                "Image.SURPRISED",
-                "Image.SILLY",
-                "Image.FABULOUS",
-                "Image.MEH",
-                "Image.YES",
-                "Image.NO",
-              ],
+          contents: [
+            {
+              _type: "text",
+              value:
+                "The micro:bit has lots of built-in pictures that you can show on the display.",
             },
-            value: "from microbit import *\n\ndisplay.show(@IMAGE@)",
-          },
+            {
+              _type: "code",
+              select: {
+                prompt: "Show example for:",
+                placeholder: "@IMAGE@",
+                options: [
+                  "Image.HEART",
+                  "Image.HEART_SMALL",
+                  "Image.HAPPY",
+                  "Image.SMILE",
+                  "Image.SAD",
+                  "Image.CONFUSED",
+                  "Image.ANGRY",
+                  "Image.ASLEEP",
+                  "Image.SURPRISED",
+                  "Image.SILLY",
+                  "Image.FABULOUS",
+                  "Image.MEH",
+                  "Image.YES",
+                  "Image.NO",
+                ],
+              },
+              value: "from microbit import *\n\ndisplay.show(@IMAGE@)",
+            },
+          ],
         },
         {
           name: "Clear the display",
-          text: "Clear the display, turning all the LEDs off:",
-          code: { value: "from microbit import *\ndisplay.clear()" },
+          contents: [
+            {
+              _type: "text",
+              value: "Clear the display, turning all the LEDs off:",
+            },
+            {
+              _type: "code",
+              value: "from microbit import *\ndisplay.clear()",
+            },
+          ],
         },
         {
           name: "Set pixels",
-          text: "You can light up individual pixels. Each pixel has a co-ordinate starting at the top left with 0,0. Use numbers 0 to 9 to select how bright you want each pixel to be, with 9 being the brightest. This will light the top left LED as bright as it can go:",
-          code: { value: "from microbit import *\ndisplay.set_pixel(0,0,9)" },
+          contents: [
+            {
+              _type: "text",
+              value:
+                "You can light up individual pixels. Each pixel has a co-ordinate starting at the top left with 0,0. Use numbers 0 to 9 to select how bright you want each pixel to be, with 9 being the brightest. This will light the top left LED as bright as it can go:",
+            },
+            {
+              _type: "code",
+              value: "from microbit import *\ndisplay.set_pixel(0,0,9)",
+            },
+          ],
         },
       ],
     },
@@ -87,19 +127,36 @@ export const pythonToolkit: Toolkit = {
       contents: [
         {
           name: "While loops",
-          text: "While loops keep a block of code running as long as something is true. Any instructions after the while statement that are indented are included in the loop.",
-          code: {
-            value:
-              "from microbit import *\nwhile True:\n    display.scroll('micro:bit')",
-          },
-          furtherText:
-            "This is a common way to have a ‘main loop’ in your program that repeats forever and allows you to continuously check and act on things like the button states or sensor readings.",
+          contents: [
+            {
+              _type: "text",
+              value:
+                "While loops keep a block of code running as long as something is true. Any instructions after the while statement that are indented are included in the loop.",
+            },
+            {
+              _type: "code",
+              value:
+                "from microbit import *\nwhile True:\n    display.scroll('micro:bit')",
+            },
+            {
+              _type: "text",
+              detail: true,
+              value:
+                "This is a common way to have a ‘main loop’ in your program that repeats forever and allows you to continuously check and act on things like the button states or sensor readings.",
+            },
+          ],
         },
         {
           name: "Control loops",
-          text: "You can use while loops to control when code is run. This will show < on the LED display when you tilt your micro:bit left, show > when you tilt it right, otherwise it clears the display.",
-          code: {
-            value: `
+          contents: [
+            {
+              _type: "text",
+              value:
+                "You can use while loops to control when code is run. This will show < on the LED display when you tilt your micro:bit left, show > when you tilt it right, otherwise it clears the display.",
+            },
+            {
+              _type: "code",
+              value: `
 from microbit import *
 while True:
     while accelerometer.is_gesture('left'):
@@ -107,18 +164,25 @@ while True:
     while accelerometer.is_gesture('right'):
         display.show('>')
     display.clear()`,
-          },
+            },
+          ],
         },
         {
           name: "Numbered for loops",
-          text: "You can use for loops to count. Although this code shows 9 numbers, it starts at 0, so you will see numbers from 0 to 8 on the LED display:",
-          code: {
-            value: `
-for n in range(9):
-    display.show(n)
-    sleep(1000)`,
-            // There's more here but complex.
-          },
+          contents: [
+            {
+              _type: "text",
+              value:
+                "You can use for loops to count. Although this code shows 9 numbers, it starts at 0, so you will see numbers from 0 to 8 on the LED display:",
+            },
+            {
+              _type: "code",
+              value: `
+                for n in range(9):
+                    display.show(n)
+                    sleep(1000)`,
+            },
+          ],
         },
       ],
     },
@@ -129,40 +193,57 @@ for n in range(9):
       contents: [
         {
           name: "Procedures",
-          text: "Procedures, also called sub-routines, are functions that perform a fixed set of instructions.\nThis function called heartbeat animates a heart on the LED display when you press button A:",
-          code: {
-            value: `from microbit import *\n\ndef heartbeat():
+          contents: [
+            {
+              _type: "text",
+              value:
+                "Procedures, also called sub-routines, are functions that perform a fixed set of instructions.\nThis function called heartbeat animates a heart on the LED display when you press button A:",
+            },
+            {
+              _type: "code",
+              value: `from microbit import *\n\ndef heartbeat():
     display.show(Image.HEART_SMALL)
     sleep(500)
     display.show(Image.HEART)
     sleep(500)
     display.clear()
-
+    
 while True:
     if button_a.was_pressed():
         heartbeat()`,
-          },
+            },
+          ],
         },
         {
           name: "Functions with parameters",
-          text: "You can pass parameters to functions. In this example, the animation runs once if you press button A, three times if you press button B:",
-          code: {
-            value: `from microbit import *\n\ndef heartbeat(h):
-    for x in range(h):
-        display.show(Image.HEART_SMALL)
-        sleep(500)
-        display.show(Image.HEART)
-        sleep(500)
-        display.clear()
-
-while True:
-    if button_a.was_pressed():
-        heartbeat(1)
-    if button_b.was_pressed():
-        heartbeat(3)`,
-          },
-          furtherText:
-            "Note that because we used a function, we only need one set of code to display the animation.",
+          contents: [
+            {
+              _type: "text",
+              value:
+                "You can pass parameters to functions. In this example, the animation runs once if you press button A, three times if you press button B:",
+            },
+            {
+              _type: "code",
+              value: `from microbit import *\n\ndef heartbeat(h):
+              for x in range(h):
+                  display.show(Image.HEART_SMALL)
+                  sleep(500)
+                  display.show(Image.HEART)
+                  sleep(500)
+                  display.clear()
+          
+          while True:
+              if button_a.was_pressed():
+                  heartbeat(1)
+              if button_b.was_pressed():
+                  heartbeat(3)`,
+            },
+            {
+              _type: "text",
+              value:
+                "Note that because we used a function, we only need one set of code to display the animation.",
+            },
+          ],
         },
       ],
     },

--- a/src/documentation/toolkit-mock-data.ts
+++ b/src/documentation/toolkit-mock-data.ts
@@ -152,10 +152,10 @@ display.show(9876543210, delay=1000, loop=True, wait=False)`,
               value: `from microbit import *
 
 display.show(Image('00300:'
-  '03630:'
-  '36963:'
-  '03630:'
-  '00300'))      
+                   '03630:'
+                   '36963:'
+                   '03630:'
+                   '00300'))      
 `,
             },
           ],


### PR DESCRIPTION
Enrich the model so it can cover most of what we have in the content. Use this to fill out the "Display" section.

We now support arbitrary arrangements of paragraphs and code snippets, any of which can be marked as "detail" and only shown in "More".

We still lack: 
- text styles (e.g. code font)
- subheadings
- hyperlinks 

The latter two need some discussion. For all of them I think it only makes sense to introduce those when moving to CMS for the content management. I don't intend to significantly further add to this mock content before we make that move.

Minor UI tweaks:

- Remove double heading in detail view
- Increase font sizes to make better use of detail view space