### PR TITLE
Use CM to render code snippets in the toolkit.

### DIFF
--- a/src/documentation/ToolkitDocumentation/TopicItem.tsx
+++ b/src/documentation/ToolkitDocumentation/TopicItem.tsx
@@ -31,6 +31,7 @@ import {
 } from "react";
 import { useSplitViewContext } from "../../common/SplitView/context";
 import { useActiveEditorActions } from "../../editor/active-editor-hooks";
+import CodeMirrorView from "../../editor/codemirror/CodeMirrorView";
 import { useRouterState } from "../../router-hooks";
 import { useScrollablePanelAncestor } from "../../workbench/ScrollablePanel";
 import {
@@ -250,7 +251,7 @@ const CodeEmbed = ({
     .trim();
   const codeRef = useRef<HTMLDivElement>(null);
   const lines = code.trim().split("\n").length;
-  const textHeight = lines * 1.5 + "em";
+  const textHeight = lines * 1.375 + "em";
   const codeHeight = `calc(${textHeight} + var(--chakra-space-5) + var(--chakra-space-5))`;
 
   return (
@@ -333,17 +334,16 @@ interface CodeProps extends BoxProps {
 const Code = forwardRef<CodeProps, "pre">(
   ({ value, ...props }: CodeProps, ref) => {
     return (
-      <Text
-        ref={ref}
-        as="pre"
+      <Box
         backgroundColor="rgb(247,245,242)"
-        padding={5}
+        p={5}
         borderTopRadius="lg"
         fontFamily="code"
         {...props}
+        ref={ref}
       >
-        <code>{value}</code>
-      </Text>
+        <CodeMirrorView value={value} />
+      </Box>
     );
   }
 );

--- a/src/editor/codemirror/CodeMirror.tsx
+++ b/src/editor/codemirror/CodeMirror.tsx
@@ -3,8 +3,9 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { EditorSelection, EditorState } from "@codemirror/state";
-import { EditorView } from "@codemirror/view";
+import { highlightActiveLineGutter, lineNumbers } from "@codemirror/gutter";
+import { EditorSelection, EditorState, Extension } from "@codemirror/state";
+import { EditorView, highlightActiveLine } from "@codemirror/view";
 import { useEffect, useMemo, useRef } from "react";
 import { useIntl } from "react-intl";
 import { createUri } from "../../language-server/client";
@@ -78,12 +79,16 @@ const CodeMirror = ({
         extensions: [
           notify,
           editorConfig,
+          // Extensions only relevant for editing:
+          lineNumbers(),
+          highlightActiveLineGutter(),
+          highlightActiveLine(),
           client ? languageServer(client, uri) : [],
           // Extensions we enable/disable based on props.
           structureHighlightingCompartment.of(
             codeStructure(options.codeStructureSettings)
           ),
-          themeExtensionsCompartment.of(themeExtensions(options.fontSize)),
+          themeExtensionsCompartment.of(themeExtensionsForOptions(options)),
         ],
       });
       const view = new EditorView({
@@ -110,7 +115,7 @@ const CodeMirror = ({
     viewRef.current!.dispatch({
       effects: [
         themeExtensionsCompartment.reconfigure(
-          themeExtensions(options.fontSize)
+          themeExtensionsForOptions(options)
         ),
         structureHighlightingCompartment.reconfigure(
           codeStructure(options.codeStructureSettings)
@@ -168,5 +173,9 @@ const CodeMirror = ({
     />
   );
 };
+
+function themeExtensionsForOptions(options: { fontSize: number }): Extension {
+  return themeExtensions(options.fontSize + "pt");
+}
 
 export default CodeMirror;

--- a/src/editor/codemirror/CodeMirrorView.tsx
+++ b/src/editor/codemirror/CodeMirrorView.tsx
@@ -1,0 +1,57 @@
+/**
+ * (c) 2021, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { Box, BoxProps } from "@chakra-ui/layout";
+import { useToken } from "@chakra-ui/system";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { useEffect, useRef } from "react";
+import "./CodeMirror.css";
+import { editorConfig } from "./config";
+import themeExtensions from "./themeExtensions";
+
+interface CodeMirrorViewProps extends BoxProps {
+  value: string;
+}
+
+/**
+ * A React component for CodeMirror 6 in read-only mode to display code snippets.
+ *
+ * This is a controlled component.
+ */
+const CodeMirrorView = ({ value, ...props }: CodeMirrorViewProps) => {
+  const elementRef = useRef<HTMLDivElement | null>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  const fontSize = useToken("fontSizes", "md");
+
+  useEffect(() => {
+    // We recreate everything if the value changes. We could optimise this.
+    const state = EditorState.create({
+      doc: value,
+      extensions: [
+        EditorView.editable.of(false),
+        editorConfig,
+        themeExtensions(fontSize),
+      ],
+    });
+    const view = new EditorView({
+      state,
+      parent: elementRef.current!,
+    });
+
+    viewRef.current = view;
+
+    return () => {
+      if (viewRef.current) {
+        viewRef.current.destroy();
+        viewRef.current = null;
+      }
+    };
+  }, [value, fontSize]);
+
+  return <Box {...props} ref={elementRef} />;
+};
+
+export default CodeMirrorView;

--- a/src/editor/codemirror/config.ts
+++ b/src/editor/codemirror/config.ts
@@ -7,7 +7,6 @@ import { completionKeymap } from "@codemirror/autocomplete";
 import { closeBrackets, closeBracketsKeymap } from "@codemirror/closebrackets";
 import { defaultKeymap, indentLess, indentMore } from "@codemirror/commands";
 import { commentKeymap } from "@codemirror/comment";
-import { highlightActiveLineGutter, lineNumbers } from "@codemirror/gutter";
 import { defaultHighlightStyle } from "@codemirror/highlight";
 import { history, historyKeymap } from "@codemirror/history";
 import { python } from "@codemirror/lang-python";
@@ -17,7 +16,6 @@ import { Compartment, EditorState, Extension, Prec } from "@codemirror/state";
 import {
   drawSelection,
   EditorView,
-  highlightActiveLine,
   highlightSpecialChars,
   KeyBinding,
   keymap,
@@ -42,7 +40,6 @@ export const editorConfig: Extension = [
     // Disable Grammarly.
     "data-gramm": "false",
   }),
-  lineNumbers(),
   highlightSpecialChars(),
   history(),
   drawSelection(),
@@ -50,8 +47,6 @@ export const editorConfig: Extension = [
   Prec.fallback(defaultHighlightStyle),
   closeBrackets(),
   highlightStyle(),
-  highlightActiveLine(),
-  highlightActiveLineGutter(),
 
   keymap.of([
     // Added, but see https://codemirror.net/6/examples/tab/ for accessibility discussion.

--- a/src/editor/codemirror/themeExtensions.ts
+++ b/src/editor/codemirror/themeExtensions.ts
@@ -5,8 +5,7 @@
  */
 import { EditorView } from "@codemirror/view";
 
-export const themeExtensions = (fontSizePt: number) => {
-  const fontSize = `${fontSizePt}pt`;
+export const themeExtensions = (fontSize: string) => {
   const fontFamily = "var(--chakra-fonts-code)";
   return EditorView.theme({
     ".cm-content": {


### PR DESCRIPTION
- Introduce new, read-only view that shares styling.
- Use it in the toolkit.

There's a noticable glitch now when the pop-up pops up, but I think we
need to revisit that anyway.