### PR TITLE
Fix unwanted auto-brackets on function imports.

### DIFF
--- a/src/e2e/autocomplete.test.ts
+++ b/src/e2e/autocomplete.test.ts
@@ -51,6 +51,15 @@ describe("Browser - autocomplete and signature help tests", () => {
     await app.findSignatureHelp("show(image)");
   });
 
+  it("does not insert brackets for import completion", async () => {
+    // This relies on undocumented Pyright behaviour so important to cover at a high level.
+    await app.selectAllInEditor();
+    await app.typeInEditor("from audio import is_pla");
+    await app.acceptCompletion("is_playing");
+
+    await app.findVisibleEditorContents(/is_playing$/);
+  });
+
   it("signature can navigate to toolkit content", async () => {
     await app.selectAllInEditor();
     // The closing bracket is autoinserted.

--- a/src/editor/codemirror/language-server/autocompletion.ts
+++ b/src/editor/codemirror/language-server/autocompletion.ts
@@ -93,7 +93,9 @@ export const autocompletion = () =>
                       { changes: { from, to, insert: item.label } },
                     ];
                     if (
-                      completion.type === "function" ||
+                      // funcParensDisabled is set to true by Pyright for e.g. a function completion in an import
+                      (completion.type === "function" &&
+                        !item.data.funcParensDisabled) ||
                       completion.type === "method"
                     ) {
                       const bracketTransaction = insertBracket(view.state, "(");


### PR DESCRIPTION
Uses Pyright flag funcParensDisabled which is undocumented so add a
e2e test to ensure we catch it if the API changes.

Closes #342