### PR TITLE
Fix list styling in topic items.

### DIFF
--- a/src/documentation/ToolkitDocumentation/TopicItem.tsx
+++ b/src/documentation/ToolkitDocumentation/TopicItem.tsx
@@ -82,7 +82,10 @@ const TopicItem = ({
       spacing={detail ? 5 : 3}
       {...props}
       fontSize={detail ? "md" : "sm"}
-      listStyle="disc inside"
+      listStylePos="inside"
+      sx={{
+        "& ul": { listStyleType: "disc" },
+      }}
     >
       {!detail && (
         <Text as="h3" fontSize="lg" fontWeight="semibold">


### PR DESCRIPTION
They're a nested list but the top-level list has a custom presentation
so better to use discs for the first one in regular copy.