### PR TITLE
Add a basic error boundary around the sidebar

### DIFF
--- a/src/common/ErrorBoundary.tsx
+++ b/src/common/ErrorBoundary.tsx
@@ -1,0 +1,40 @@
+import { Text } from "@chakra-ui/layout";
+import React, { ErrorInfo } from "react";
+import { LoggingContext } from "../logging/logging-hooks";
+
+interface State {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends React.Component<{}, State> {
+  context!: React.ContextType<typeof LoggingContext>;
+
+  constructor(props: {}) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(_error: any) {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: any, _errorInfo: ErrorInfo) {
+    this.context?.error(error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Text p={5}>
+          Something went wrong. Download your HEX file for safe keeping, then
+          refresh the page to reload.
+        </Text>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+ErrorBoundary.contextType = LoggingContext;
+
+export default ErrorBoundary;

--- a/src/common/ErrorBoundary.tsx
+++ b/src/common/ErrorBoundary.tsx
@@ -26,7 +26,7 @@ class ErrorBoundary extends React.Component<{}, State> {
     if (this.state.hasError) {
       return (
         <Text p={5}>
-          Something went wrong. Download your HEX file for safe keeping, then
+          Something went wrong. Download your hex file for safe keeping, then
           refresh the page to reload.
         </Text>
       );

--- a/src/documentation/ToolkitDocumentation/ToolkitDocumentation.tsx
+++ b/src/documentation/ToolkitDocumentation/ToolkitDocumentation.tsx
@@ -129,8 +129,7 @@ const ActiveTooklitLevel = ({
             />
           }
         >
-          {topic.introduction!.length > 0 &&
-            topic.introduction &&
+          {topic.introduction &&
             (typeof topic.introduction === "string" ? (
               <Text p={5} pb={1} fontSize="md">
                 {topic.introduction}

--- a/src/documentation/ToolkitDocumentation/ToolkitDocumentation.tsx
+++ b/src/documentation/ToolkitDocumentation/ToolkitDocumentation.tsx
@@ -129,7 +129,8 @@ const ActiveTooklitLevel = ({
             />
           }
         >
-          {topic.introduction &&
+          {topic.introduction!.length > 0 &&
+            topic.introduction &&
             (typeof topic.introduction === "string" ? (
               <Text p={5} pb={1} fontSize="md">
                 {topic.introduction}

--- a/src/logging/logging-hooks.ts
+++ b/src/logging/logging-hooks.ts
@@ -6,7 +6,8 @@
 import { createContext, useContext } from "react";
 import { Logging } from "./logging";
 
-const LoggingContext = createContext<Logging | undefined>(undefined);
+// Exported for class-based error boundary.
+export const LoggingContext = createContext<Logging | undefined>(undefined);
 
 export const LoggingProvider = LoggingContext.Provider;
 

--- a/src/workbench/SideBar.tsx
+++ b/src/workbench/SideBar.tsx
@@ -33,6 +33,7 @@ import { useRouterState } from "../router-hooks";
 import SettingsMenu from "../settings/SettingsMenu";
 import FeedbackArea from "./FeedbackArea";
 import HelpMenu from "./HelpMenu";
+import ErrorBoundary from "../common/ErrorBoundary";
 
 interface SideBarProps extends BoxProps {
   selectedFile: string | undefined;
@@ -202,8 +203,10 @@ const SideBarContents = ({ panes, ...props }: SideBarContentsProps) => {
           {panes.map((p) => (
             <TabPanel key={p.id} p={0} height="100%">
               <Flex height="100%" direction="column">
-                {p.nav && <HStack justifyContent="flex-end">{p.nav}</HStack>}
-                {p.contents}
+                <ErrorBoundary>
+                  {p.nav && <HStack justifyContent="flex-end">{p.nav}</HStack>}
+                  {p.contents}
+                </ErrorBoundary>
               </Flex>
             </TabPanel>
           ))}


### PR DESCRIPTION
Aiming to avoid any issue with the sidebar affecting the rest of the app.

Immediate motivation is the migration of the introduction field on #332 which might cause such issues temporarily.