### PR TITLE
Add a flag to disable the welcome dialog.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,24 @@ An example of how to use jest options to filter to a specific subset of the test
 Builds the app for production to the `build` folder.\
 It correctly bundles React in production mode and optimizes the build for the best performance.
 
+## Feature flags
+
+The editor supports a simple runtime feature flag system to:
+
+- allow work-in-progress features to be integrated before they're ready for general use
+- allow scenarios to be set up for user testing
+- enable debug features
+
+This system may change without notice. Flags are regularly added and removed.
+
+The current set of flags are documented in [the source](./src/flags.ts).
+
+Flags may be specified via the query string with repeated `flag` parameters,
+for example, http://localhost:3000/?flag=oneFlag&flag=anotherFlag
+
+By default, all flags are enabled for local development and branches builds.
+They can be disabled with the special flag `none`.
+
 ## Translations
 
 We use react-intl from [FormatJS](https://formatjs.io/) to manage strings for translation.

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -12,20 +12,39 @@
 
 import { stage } from "./environment";
 
-type Flag = "dnd" | "dndDebug"; // Should be union of strings.
+// A union of the flag names.
+type Flag =
+  /**
+   * Enables experimental drag and drop features.
+   */
+  | "dnd"
+  /**
+   * Enables verbose debug logging to the console of drag events.
+   */
+  | "dndDebug"
+  /**
+   * Disables the pop-up welcome dialog.
+   * The dialog is still available from the alpha release notice UI.
+   * Added to support user-testing.
+   *
+   * The flag has the nice side-effect of disabling the dialog for
+   * local development so is worth keeping for that use alone.
+   */
+  | "noWelcome";
+
+const allFlags: Flag[] = ["dnd", "dndDebug", "noWelcome"];
 
 type Flags = Record<Flag, boolean>;
 
 export const flags: Flags = (() => {
   const isPreviewStage = !(stage === "STAGING" || stage === "PRODUCTION");
-  const flags: Flag[] = ["dnd", "dndDebug"];
   const params = new URLSearchParams(window.location.search);
   const enableFlags = new Set(params.getAll("flag"));
   const allFlagsEnabled = enableFlags.has("*");
   // To allow local testing of no-flag state.
   const allFlagsDisabled = enableFlags.has("none");
   return Object.fromEntries(
-    flags.map((f) => {
+    allFlags.map((f) => {
       return [
         f,
         !allFlagsDisabled &&

--- a/src/workbench/ReleaseNotice.tsx
+++ b/src/workbench/ReleaseNotice.tsx
@@ -3,6 +3,7 @@ import { Flex, HStack, Text } from "@chakra-ui/layout";
 import { useCallback, useEffect, useState } from "react";
 import { RiFeedbackFill, RiInformationFill } from "react-icons/ri";
 import { useLocalStorage } from "../common/use-local-storage";
+import { flags } from "../flags";
 
 export type ReleaseNoticeState = "info" | "feedback" | "closed";
 
@@ -34,11 +35,7 @@ export const useReleaseDialogState = (): [
     useState<ReleaseNoticeState>("closed");
   // Show the dialog on start-up once per user.
   useEffect(() => {
-    if (document.domain === "localhost") {
-      // Skip to avoid e2e and dev annoyance.
-      return;
-    }
-    if (storedNotice.version < currentVersion) {
+    if (!flags.noWelcome && storedNotice.version < currentVersion) {
       setReleaseDialog("info");
       setStoredNotice({ version: currentVersion });
     }

--- a/src/workbench/flags.test.ts
+++ b/src/workbench/flags.test.ts
@@ -1,0 +1,45 @@
+import { flagsForParams } from "../flags";
+
+describe("flags", () => {
+  it("enables everything in REVIEW", () => {
+    const params = new URLSearchParams([]);
+
+    const flags = flagsForParams("REVIEW", params);
+
+    expect(Object.values(flags).every((x) => x)).toEqual(true);
+  });
+
+  for (const stage of ["STAGING", "PRODUCTION"]) {
+    it("enables nothing in " + stage, () => {
+      const params = new URLSearchParams([]);
+
+      const flags = flagsForParams(stage, params);
+
+      expect(Object.values(flags).every((x) => x)).toEqual(false);
+    });
+  }
+
+  it("enable specific flag", () => {
+    const params = new URLSearchParams([["flag", "noWelcome"]]);
+
+    const flags = flagsForParams("PRODUCTION", params);
+
+    expect(
+      Object.entries(flags).every(
+        ([flag, status]) => (flag === "noWelcome") === status
+      )
+    ).toEqual(true);
+  });
+
+  it("can combine none with specific enabled flags in REVIEW", () => {
+    const params = new URLSearchParams([
+      ["flag", "none"],
+      ["flag", "noWelcome"],
+    ]);
+
+    const flags = flagsForParams("REVIEW", params);
+
+    expect(flags.dnd).toBe(false);
+    expect(flags.noWelcome).toBe(true);
+  });
+});


### PR DESCRIPTION
We plan to use this for user testing, particularly with the French
translation as we won't be translating this dialog.

Add docs for flags.

I've tweaked the flag logic so flags can be tested in isolation on review branches by allowing you to specify "none" as well as a flag to enable. Previously "none" ignored any other explicitly specified flags.

Closes #372.