### PR TITLE
Get the V2 compatibility information from the CMS.

### DIFF
--- a/src/documentation/ToolkitDocumentation/ToolkitDocumentation.tsx
+++ b/src/documentation/ToolkitDocumentation/ToolkitDocumentation.tsx
@@ -7,7 +7,7 @@ import { usePrevious } from "@chakra-ui/hooks";
 import { Box, List } from "@chakra-ui/layout";
 import { useCallback } from "react";
 import { useRouterParam } from "../../router-hooks";
-import { Toolkit, ToolkitNavigationState } from "./model";
+import { isV2Only, Toolkit, ToolkitNavigationState } from "./model";
 import ToolkitBreadcrumbHeading from "./ToolkitBreadcrumbHeading";
 import ToolkitContent from "./ToolkitContent";
 import ToolkitLevel from "./ToolkitLevel";
@@ -169,7 +169,7 @@ const ActiveTooklitLevel = ({
         {toolkit.contents?.map((topic) => (
           <ToolkitTopLevelListItem
             key={topic.name}
-            name={topic.name}
+            name={topic.name + (isV2Only(topic) ? " (V2)" : "")}
             description={topic.subtitle}
             onForward={() =>
               onNavigate({

--- a/src/documentation/ToolkitDocumentation/TopicItem.tsx
+++ b/src/documentation/ToolkitDocumentation/TopicItem.tsx
@@ -6,7 +6,7 @@
 import { BoxProps, Flex, Stack, Text } from "@chakra-ui/layout";
 import { Select } from "@chakra-ui/select";
 import { ChangeEvent, useCallback, useState } from "react";
-import { ToolkitTopic, ToolkitTopicEntry } from "./model";
+import { isV2Only, ToolkitTopic, ToolkitTopicEntry } from "./model";
 import ToolkitContent from "./ToolkitContent";
 
 interface TopicItemProps extends BoxProps {
@@ -54,6 +54,7 @@ const TopicItem = ({
       {!detail && (
         <Text as="h3" fontSize="lg" fontWeight="semibold">
           {item.name}
+          {isV2Only(item) ? " (V2)" : ""}
         </Text>
       )}
       <ToolkitContent

--- a/src/documentation/ToolkitDocumentation/api.ts
+++ b/src/documentation/ToolkitDocumentation/api.ts
@@ -9,11 +9,11 @@ import { Toolkit } from "./model";
 // Might revisit depending on eventual size.
 const toolkitQuery = `
   *[_type == "toolkit" && id=="explore" && !(_id in path("drafts.**"))]{
-    id, name, description, 
+    id, name, description,
     contents[]->{
-      name, subtitle, introduction, 
+      name, compatibility, subtitle, introduction,
       contents[]->{
-        name, content, alternativesLabel, alternatives, detailContent
+        name, compatibility, content, alternativesLabel, alternatives, detailContent
       }
     }
   }`;

--- a/src/documentation/ToolkitDocumentation/model.ts
+++ b/src/documentation/ToolkitDocumentation/model.ts
@@ -11,7 +11,13 @@ export interface Toolkit {
   contents?: ToolkitTopic[];
 }
 
-export interface ToolkitTopic {
+type Product = "microbitV1" | "microbitV2";
+
+interface HasCompatibility {
+  compatibility: Product[];
+}
+
+export interface ToolkitTopic extends HasCompatibility {
   name: string;
   /**
    * Short, for the listing.
@@ -55,7 +61,7 @@ interface ToolkitAlternative {
   content: ToolkitPortableText;
 }
 
-export interface ToolkitTopicEntry {
+export interface ToolkitTopicEntry extends HasCompatibility {
   name: string;
   content: ToolkitPortableText;
   // Should be co-present with alternatives.
@@ -80,3 +86,14 @@ export interface ToolkitNavigationState {
   topicId?: string;
   itemId?: string;
 }
+
+// Although the data model is more flexible, in the UI we just want to
+// show a V2 marker for newer board features.
+export const isV2Only = (compatible: HasCompatibility) => {
+  return (
+    // This will be defined everywhere shortly, but for now we need to cope before the migration.
+    compatible.compatibility &&
+    compatible.compatibility.length === 1 &&
+    compatible.compatibility[0] === "microbitV2"
+  );
+};


### PR DESCRIPTION
The data hasn't yet been migrated but we'll do it in one step, moving it
from the title to the new `compatibility` field.

See #330  which will be resolved once this is merged and the compatibility info subsequently migrated from title suffixes to the new CMS fields.