### PR TITLE
Highlight activated reference entry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ _steps:
   install_dependencies: &install_dependencies
     run: npm ci --cache .npm-cache && sudo npm i -g --registry https://npm.pkg.github.com/microbit-foundation @microbit-foundation/website-deploy-aws@0.2.0 @microbit-foundation/website-deploy-aws-config@0.4.2 @microbit-foundation/circleci-npm-package-versioner@1
   install_theme: &install_theme
-    run: npm install --no-save --registry https://npm.pkg.github.com/microbit-foundation @microbit-foundation/python-editor-next-microbit@0.1.0-dev.77
+    run: npm install --no-save --registry https://npm.pkg.github.com/microbit-foundation @microbit-foundation/python-editor-next-microbit@0.1.0-dev.79
   update_version: &update_version
     run: npm run ci:update-version
   build: &build

--- a/src/documentation/ToolkitDocumentation/Highlight.tsx
+++ b/src/documentation/ToolkitDocumentation/Highlight.tsx
@@ -6,8 +6,11 @@ interface HighlightProps extends BoxProps {
 
 const Highlight = ({ value, children, ...props }: HighlightProps) => {
   const style = value
-    ? { backgroundColor: "brand.100" }
-    : { transition: "background-color ease-in 0.5s" };
+    ? {
+        backgroundColor: "brand.100",
+        transition: "background-color ease-out 0.2s",
+      }
+    : { transition: "background-color ease-in 0.6s" };
   return (
     <Box {...props} {...style} borderLeftRadius="md">
       {children}

--- a/src/documentation/ToolkitDocumentation/Highlight.tsx
+++ b/src/documentation/ToolkitDocumentation/Highlight.tsx
@@ -6,10 +6,10 @@ interface HighlightProps extends BoxProps {
 
 const Highlight = ({ value, children, ...props }: HighlightProps) => {
   const style = value
-    ? { backgroundColor: "blue.200" }
+    ? { backgroundColor: "#e1dbF3" }
     : { transition: "background-color ease-in 0.5s" };
   return (
-    <Box {...props} {...style}>
+    <Box {...props} {...style} borderLeftRadius="md">
       {children}
     </Box>
   );

--- a/src/documentation/ToolkitDocumentation/Highlight.tsx
+++ b/src/documentation/ToolkitDocumentation/Highlight.tsx
@@ -6,7 +6,7 @@ interface HighlightProps extends BoxProps {
 
 const Highlight = ({ value, children, ...props }: HighlightProps) => {
   const style = value
-    ? { backgroundColor: "#e1dbF3" }
+    ? { backgroundColor: "brand.100" }
     : { transition: "background-color ease-in 0.5s" };
   return (
     <Box {...props} {...style} borderLeftRadius="md">

--- a/src/documentation/ToolkitDocumentation/Highlight.tsx
+++ b/src/documentation/ToolkitDocumentation/Highlight.tsx
@@ -1,0 +1,18 @@
+import { Box, BoxProps } from "@chakra-ui/react";
+
+interface HighlightProps extends BoxProps {
+  value: boolean;
+}
+
+const Highlight = ({ value, children, ...props }: HighlightProps) => {
+  const style = value
+    ? { backgroundColor: "blue.200" }
+    : { transition: "background-color ease-in 0.5s" };
+  return (
+    <Box {...props} {...style}>
+      {children}
+    </Box>
+  );
+};
+
+export default Highlight;

--- a/src/documentation/reference/ReferenceNode.tsx
+++ b/src/documentation/reference/ReferenceNode.tsx
@@ -121,10 +121,7 @@ const ReferenceNode = ({ anchor, docs, ...others }: ApiDocEntryNodeProps) => {
         value={highlighting}
         mt={1}
         mb={1}
-        pl={3}
-        pr={3}
-        pt={3}
-        pb={3}
+        p={3}
       >
         <ReferenceNodeSelf
           docs={docs}

--- a/src/documentation/reference/ReferenceNode.tsx
+++ b/src/documentation/reference/ReferenceNode.tsx
@@ -50,13 +50,7 @@ interface ApiDocEntryNodeProps extends BoxProps {
   anchor?: Anchor;
 }
 
-const ReferenceNode = ({
-  anchor,
-  docs,
-  mt,
-  mb,
-  ...others
-}: ApiDocEntryNodeProps) => {
+const ReferenceNode = ({ anchor, docs, ...others }: ApiDocEntryNodeProps) => {
   const { kind, fullName } = docs;
   const disclosure = useDisclosure();
 
@@ -106,15 +100,15 @@ const ReferenceNode = ({
       id={fullName}
       wordBreak="break-word"
       mb={kindToSpacing[kind]}
-      {...others}
       _hover={{
         "& button": {
           display: "flex",
         },
       }}
       fontSize="sm"
+      {...others}
     >
-      <Highlight value={highlighting}>
+      <Highlight value={highlighting} mt={1} mb={1} pl={3} pr={3} pt={3} pb={3}>
         <ReferenceNodeSelf
           docs={docs}
           showMore={disclosure.isOpen}

--- a/src/documentation/reference/ReferenceNode.tsx
+++ b/src/documentation/reference/ReferenceNode.tsx
@@ -10,7 +10,7 @@ import {
   usePrefersReducedMotion,
   usePrevious,
 } from "@chakra-ui/react";
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { FormattedMessage, IntlShape, useIntl } from "react-intl";
 import { splitDocString } from "../../editor/codemirror/language-server/documentation";
 import {
@@ -24,6 +24,7 @@ import { useScrollablePanelAncestor } from "../../workbench/ScrollablePanel";
 import DocString from "../common/DocString";
 import ShowMoreButton from "../common/ShowMoreButton";
 import { allowWrapAtPeriods } from "../common/wrap";
+import Highlight from "../ToolkitDocumentation/Highlight";
 
 const kindToFontSize: Record<string, any> = {
   module: "2xl",
@@ -66,6 +67,7 @@ const ReferenceNode = ({
   const scrollable = useScrollablePanelAncestor();
   const prefersReducedMotion = usePrefersReducedMotion();
   const logging = useLogging();
+  const [highlighting, setHighlighting] = useState(false);
   useEffect(() => {
     if (previousAnchor !== anchor && active) {
       logging.log("Activating " + fullName);
@@ -79,6 +81,12 @@ const ReferenceNode = ({
             behavior: prefersReducedMotion ? "auto" : "smooth",
           });
         }
+        setTimeout(() => {
+          setHighlighting(true);
+          setTimeout(() => {
+            setHighlighting(false);
+          }, 3000);
+        }, 300);
       }, 150);
     }
   }, [
@@ -106,12 +114,14 @@ const ReferenceNode = ({
       }}
       fontSize="sm"
     >
-      <ReferenceNodeSelf
-        docs={docs}
-        showMore={disclosure.isOpen}
-        onToggleShowMore={disclosure.onToggle}
-      />
-      <ReferenceNodeChildren docs={docs} anchor={anchor} />
+      <Highlight value={highlighting}>
+        <ReferenceNodeSelf
+          docs={docs}
+          showMore={disclosure.isOpen}
+          onToggleShowMore={disclosure.onToggle}
+        />
+        <ReferenceNodeChildren docs={docs} anchor={anchor} />
+      </Highlight>
     </Box>
   );
 };

--- a/src/documentation/reference/ReferenceNode.tsx
+++ b/src/documentation/reference/ReferenceNode.tsx
@@ -10,7 +10,13 @@ import {
   usePrefersReducedMotion,
   usePrevious,
 } from "@chakra-ui/react";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { FormattedMessage, IntlShape, useIntl } from "react-intl";
 import { splitDocString } from "../../editor/codemirror/language-server/documentation";
 import {
@@ -93,7 +99,9 @@ const ReferenceNode = ({ anchor, docs, ...others }: ApiDocEntryNodeProps) => {
     disclosure,
     fullName,
   ]);
-
+  const handleHighlightClick = useCallback(() => {
+    setHighlighting(false);
+  }, [setHighlighting]);
   return (
     <Box
       ref={ref}
@@ -108,7 +116,16 @@ const ReferenceNode = ({ anchor, docs, ...others }: ApiDocEntryNodeProps) => {
       fontSize="sm"
       {...others}
     >
-      <Highlight value={highlighting} mt={1} mb={1} pl={3} pr={3} pt={3} pb={3}>
+      <Highlight
+        onClick={handleHighlightClick}
+        value={highlighting}
+        mt={1}
+        mb={1}
+        pl={3}
+        pr={3}
+        pt={3}
+        pb={3}
+      >
         <ReferenceNodeSelf
           docs={docs}
           showMore={disclosure.isOpen}

--- a/src/documentation/reference/ReferenceToolkit.tsx
+++ b/src/documentation/reference/ReferenceToolkit.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { List } from "@chakra-ui/layout";
+import { List, ListItem, Divider } from "@chakra-ui/layout";
 import sortBy from "lodash.sortby";
 import { useCallback } from "react";
 import { useIntl } from "react-intl";
@@ -14,7 +14,6 @@ import { allowWrapAtPeriods } from "../common/wrap";
 import { useAnimationDirection } from "../ToolkitDocumentation/toolkit-hooks";
 import ToolkitBreadcrumbHeading from "../ToolkitDocumentation/ToolkitBreadcrumbHeading";
 import ToolkitLevel from "../ToolkitDocumentation/ToolkitLevel";
-import ToolkitListItem from "../ToolkitDocumentation/ToolkitListItem";
 import ToolkitTopLevelHeading from "../ToolkitDocumentation/ToolkitTopLevelHeading";
 import ToolkitTopLevelListItem from "../ToolkitDocumentation/ToolkitTopLevelListItem";
 import { resolveModule } from "./apidocs-util";
@@ -74,9 +73,10 @@ const ActiveToolkitLevel = ({
       >
         <List flex="1 1 auto">
           {(module.children ?? []).map((child) => (
-            <ToolkitListItem key={child.id}>
-              <ReferenceNode docs={child} width="100%" anchor={anchor} />
-            </ToolkitListItem>
+            <ListItem key={child.id}>
+              <ReferenceNode docs={child} width="100%" anchor={anchor} mb={0} />
+              <Divider />
+            </ListItem>
           ))}
         </List>
       </ToolkitLevel>


### PR DESCRIPTION
This is based on the design in Search which applies to Explore not Reference so adapted a little.

I've stopped using ToolkitListItem here as I needed to significantly change the spacing as I needed padding inside of the highlight rather than margin around it. I think perhaps it should only be used for the top level list in Explore now and therefore can probably be removed in time.

To be honest, I'm not sure the second level should be a list at all, what we have is content in sections with titles. I'll review that separately.

It makes the problem with overrides much more obvious (e.g. display.show) but I think that's just incentive to fix it soon, not a blocker for this.

See #376 