### PR TITLE
Remove unhelpful alt text.

### DIFF
--- a/src/documentation/ToolkitDocumentation/ToolkitBreadcrumbHeading.tsx
+++ b/src/documentation/ToolkitDocumentation/ToolkitBreadcrumbHeading.tsx
@@ -67,7 +67,7 @@ const ToolkitBreadcrumbHeading = ({
         {icon && (
           <Image
             src={imageUrlBuilder.image(icon.asset).url()}
-            alt="Topic icon"
+            alt=""
             width="80px"
             height="64px"
             borderRadius="lg"

--- a/src/documentation/ToolkitDocumentation/ToolkitTopLevelListItem.tsx
+++ b/src/documentation/ToolkitDocumentation/ToolkitTopLevelListItem.tsx
@@ -83,7 +83,7 @@ const ToolkitListItem = ({
         {showIcon && icon && (
           <Image
             src={imageUrlBuilder.image(icon.asset).url()}
-            alt="Topic icon"
+            alt=""
             width="80px"
             height="64px"
             borderRadius="lg"


### PR DESCRIPTION
The text we already have is sufficient; the icons are just decorative
(or will be, when we add them).