### PR TITLE
Search top level

### DIFF
--- a/src/documentation/search-hooks.tsx
+++ b/src/documentation/search-hooks.tsx
@@ -158,6 +158,12 @@ const exploreSearchableContent = (
   const content: SearchableContent[] = [];
   if (state.status === "ok") {
     state.toolkit.contents?.forEach((t) => {
+      content.push({
+        id: t.slug.current,
+        title: t.name,
+        containerTitle: t.name,
+        content: t.subtitle + ".\n\n" + blocksToText(t.introduction),
+      });
       t.contents?.forEach((e) => {
         const contentString = blocksToText(e.content);
         const detailContentString = blocksToText(e.detailContent);

--- a/src/documentation/search-hooks.tsx
+++ b/src/documentation/search-hooks.tsx
@@ -199,6 +199,12 @@ const referenceSearchableContent = (
   };
   if (toolkit) {
     for (const module of Object.values(toolkit)) {
+      content.push({
+        id: module.id,
+        title: module.fullName,
+        containerTitle: module.fullName,
+        content: validateString(module.docString),
+      });
       addNestedDocs(module.fullName, module.children);
     }
   }


### PR DESCRIPTION
Adds the ability to search the top level (topics for the explore content and modules for the reference content). The explore topic introduction text is also searchable, and links to the topic as opposed to any specific topic entry.

See #440 