### PR TITLE
Language aware search (just French for now)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13632,6 +13632,11 @@
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
     },
+    "lunr-languages": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/lunr-languages/-/lunr-languages-1.9.0.tgz",
+      "integrity": "sha512-Be5vFuc8NAheOIjviCRms3ZqFFBlzns3u9DXpPSZvALetgnydAN0poV71pVLFn0keYy/s4VblMMkqewTLe+KPg=="
+    },
     "lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "framer-motion": "^3.10.6",
     "lodash.sortby": "^4.7.0",
     "lunr": "^2.3.9",
+    "lunr-languages": "^1.9.0",
     "lzma": "^2.3.2",
     "marked": "^4.0.10",
     "react": "^17.0.2",

--- a/src/documentation/explore/api.ts
+++ b/src/documentation/explore/api.ts
@@ -13,7 +13,7 @@ const toolkitQuery = (languageId: string): string => {
   }
   return `
   *[_type == "toolkit" && language == "${languageId}" && slug.current == "explore" && !(_id in path("drafts.**"))]{
-    id, name, description,
+    id, name, description, language,
     contents[]->{
       name, slug, compatibility, subtitle, image,
       introduction[] {

--- a/src/documentation/explore/model.ts
+++ b/src/documentation/explore/model.ts
@@ -11,6 +11,7 @@ export interface Toolkit {
   name: string;
   description: string;
   contents?: ToolkitTopic[];
+  language: string;
 }
 
 type Product = "microbitV1" | "microbitV2";

--- a/src/documentation/search/lunr-languages.d.ts
+++ b/src/documentation/search/lunr-languages.d.ts
@@ -1,0 +1,16 @@
+declare module "lunr-languages/lunr.stemmer.support";
+
+declare module "lunr-languages/lunr.*" {
+  import lunr from "lunr";
+  function register(l: typeof lunr): void;
+  export = register;
+}
+
+declare namespace lunr {
+  import { Builder } from "lunr";
+  export function multiLanguage(...lang: string[]): Builder.Plugin;
+
+  // Add more here.
+  // I don't think we can use module augmentation—lunr is a namespace.
+  export const fr: Builder.Plugin;
+}

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -14,6 +14,9 @@ export interface Language {
   enName: string;
 }
 
+// When we add languages we need to update the toolkit search indexing,
+// which will require the dynamic import of a new language plugin for lunr.
+// See search.ts.
 export const supportedLanguages: Language[] = [
   {
     id: "en",


### PR DESCRIPTION
You can see that the French support is split out into build/static/js/1.67d6d668.chunk.worker.js and is loaded dynamically, so this approach will scale as we add languages.

Depends on #479 (review/merge that first, then I'll rebase for easier review here)

See #452 