### PR TITLE
Disable flags for e2e tests.

### DIFF
--- a/src/e2e/migration.test.ts
+++ b/src/e2e/migration.test.ts
@@ -3,13 +3,13 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { App, defaultRootUrl } from "./app";
+import { App } from "./app";
 
 describe("Browser - migration", () => {
-  const app = new App(
-    defaultRootUrl +
-      "/#project:XQAAgACRAAAAAAAAAAA9iImmlGSt1R++5LD+ZJ36cRz46B+lhYtNRoWF0nijpaVyZlK7ACfSpeoQpgfk21st4ty06R4PEOM4sSAXBT95G3en+tghrYmE+YJp6EiYgzA9ThKkyShWq2UdvmCzqxoNfYc1wlmTqlNv/Piaz3WoSe3flvr/ItyLl0aolQlEpv4LA8A="
-  );
+  const app = new App({
+    fragment:
+      "#project:XQAAgACRAAAAAAAAAAA9iImmlGSt1R++5LD+ZJ36cRz46B+lhYtNRoWF0nijpaVyZlK7ACfSpeoQpgfk21st4ty06R4PEOM4sSAXBT95G3en+tghrYmE+YJp6EiYgzA9ThKkyShWq2UdvmCzqxoNfYc1wlmTqlNv/Piaz3WoSe3flvr/ItyLl0aolQlEpv4LA8A=",
+  });
   beforeEach(app.reset.bind(app));
   afterEach(app.screenshot.bind(app));
   afterAll(app.dispose.bind(app));

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -13,7 +13,7 @@
 import { stage as stageFromEnvironment } from "./environment";
 
 // A union of the flag names.
-type Flag =
+export type Flag =
   /**
    * Enables verbose debug logging to the console of drag events.
    */


### PR DESCRIPTION
Add system to opt into specific flags.
Default the noWelcome flag as otherwise every test must deal with the dialog.

The system to pass flags is currently unused, but I'll add a search test soon to
prove it works.