### PR TITLE
Try to switch away from homepage to PUBLIC_URL.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ _steps:
   serve: &serve
     run:
       name: Serve files for e2e tests
-      command: npm run serve
+      command: mkdir /tmp/app && cp -r build /tmp/app${PUBLIC_URL} && npx serve --no-clipboard -l 3000 /tmp/app
       background: true
   serve-wait: &serve-wait
     run:
@@ -99,6 +99,13 @@ jobs:
       - *install_theme
       - *update_version
       - *save_npm_cache
+      # Set PUBLIC_URL based on the bucket prefix. PUBLIC_URL is equivalent to CRA's package.json homepage setting https://create-react-app.dev/docs/advanced-configuration/
+      - run:
+          name: "Set PUBLIC_URL for review branch"
+          environment:
+            NODE_PATH: /usr/local/lib/node_modules
+          # Two env vars as PUBLIC_URL seems to be blank when running jest even if we set it.
+          command: URL=$(npm run --silent public-url); echo "export PUBLIC_URL=$URL && export E2E_PUBLIC_URL=$URL" >> $BASH_ENV
       - *build
       # Unlike other stages deploy, first so we still get deployments when e2e fails.
       - *queue_until_front_of_line

--- a/bin/public-url.js
+++ b/bin/public-url.js
@@ -1,0 +1,16 @@
+/**
+ * Used by the CI build to output the bucket prefix to use as the
+ * PUBLIC_URL environement variable.
+ *
+ * (c) 2022, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+const {
+  createDeploymentDetailsWithReviewPrefixes,
+} = require("@microbit-foundation/website-deploy-aws-config");
+
+const {
+  s3Config: { bucketPrefix },
+} = createDeploymentDetailsWithReviewPrefixes();
+console.log(`/${bucketPrefix}/`);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "python-editor",
   "version": "0.1.0-local",
   "private": true,
-  "homepage": ".",
   "dependencies": {
     "@chakra-ui/icons": "^1.0.15",
     "@chakra-ui/react": "^1.6.7",
@@ -88,7 +87,8 @@
     "invalidate": "aws cloudfront create-invalidation --distribution-id $(printenv ${STAGE}_CLOUDFRONT_DISTRIBUTION_ID) --paths \"/*\"",
     "i18n:compile": "node bin/sort.js && formatjs compile-folder --ast lang src/messages",
     "i18n:convert": "node bin/sort.js && node bin/crowdin-convert.js",
-    "fix-licensing-headers": "node bin/fix-licensing-headers.js"
+    "fix-licensing-headers": "node bin/fix-licensing-headers.js",
+    "public-url": "node bin/public-url.js"
   },
   "eslintConfig": {
     "extends": [

--- a/src/e2e/app.ts
+++ b/src/e2e/app.ts
@@ -75,10 +75,11 @@ export class App {
     ]);
     this.url =
       baseUrl +
-      "/?" +
+      // We don't use PUBLIC_URL here as CRA seems to set it to "" before running jest.
+      (process.env.E2E_PUBLIC_URL ?? "/") +
+      "?" +
       new URLSearchParams(Array.from(flags).map((f) => ["flag", f])) +
       (options.fragment ?? "");
-
     this.browser = puppeteer.launch();
     this.page = this.createPage();
   }


### PR DESCRIPTION
Set the url to the actual path.

This is motivated by the difficulties on #464 where a worker doing an async import gets the wrong source location as the relative path is resolved relative to the worker script not index.html as it would usually be.