### PR TITLE
Adjust reference toolkit spacing

### DIFF
--- a/src/documentation/reference/ReferenceNode.tsx
+++ b/src/documentation/reference/ReferenceNode.tsx
@@ -81,14 +81,9 @@ const ReferenceNode = ({
         }}
         fontSize="sm"
         spacing={3}
-        pt={
-          parentType !== "class" ? kindToSpacing[kind] : kindToSpacing[kind] - 1
-        }
-        pb={
-          parentType !== "class"
-            ? kindToSpacing[kind] - 1
-            : kindToSpacing[kind] - 2
-        }
+        // Reduce padding inside a class.
+        pt={kindToSpacing[kind] - (parentType === "class" ? 1 : 0)}
+        pb={kindToSpacing[kind] - (parentType === "class" ? 2 : 1)}
         pl={5}
         pr={3}
         mt={1}

--- a/src/documentation/reference/ReferenceNode.tsx
+++ b/src/documentation/reference/ReferenceNode.tsx
@@ -77,9 +77,10 @@ const ReferenceNode = ({ anchor, docs, ...props }: ApiDocEntryNodeProps) => {
         fontSize="sm"
         spacing={3}
         p={5}
+        pb={3}
         pr={3}
         mt={1}
-        mb={kindToSpacing[kind]}
+        mb={1}
         {...props}
       >
         <ReferenceNodeSelf

--- a/src/documentation/reference/ReferenceNode.tsx
+++ b/src/documentation/reference/ReferenceNode.tsx
@@ -81,8 +81,14 @@ const ReferenceNode = ({
         }}
         fontSize="sm"
         spacing={3}
-        pt={parentType !== "class" ? kindToSpacing[kind] : 2}
-        pb={parentType !== "class" ? kindToSpacing[kind] - 1 : 1}
+        pt={
+          parentType !== "class" ? kindToSpacing[kind] : kindToSpacing[kind] - 1
+        }
+        pb={
+          parentType !== "class"
+            ? kindToSpacing[kind] - 1
+            : kindToSpacing[kind] - 2
+        }
         pl={5}
         pr={3}
         mt={1}

--- a/src/documentation/reference/ReferenceNode.tsx
+++ b/src/documentation/reference/ReferenceNode.tsx
@@ -38,6 +38,13 @@ const kindToHeading: Record<string, any> = {
   function: "h4",
 };
 
+const kindToSpacing: Record<string, any> = {
+  module: 5,
+  class: 5,
+  variable: 4,
+  function: 4,
+};
+
 export const classToInstanceMap: Record<string, string> = {
   Button: "button_a",
   MicroBitDigitalPin: "pin0",
@@ -49,11 +56,16 @@ export const classToInstanceMap: Record<string, string> = {
 interface ApiDocEntryNodeProps extends BoxProps {
   docs: ApiDocsEntry;
   anchor?: Anchor;
+  parentType?: string;
 }
 
-const ReferenceNode = ({ anchor, docs, ...props }: ApiDocEntryNodeProps) => {
-  const { id } = docs;
-
+const ReferenceNode = ({
+  anchor,
+  docs,
+  parentType,
+  ...props
+}: ApiDocEntryNodeProps) => {
+  const { id, kind } = docs;
   // Numeric suffixes are used for overrides but links may omit them when
   // a specific override is not known and we should match the first only.
   const active = anchor && (anchor.id === id || anchor.id + "-1" === id);
@@ -69,8 +81,9 @@ const ReferenceNode = ({ anchor, docs, ...props }: ApiDocEntryNodeProps) => {
         }}
         fontSize="sm"
         spacing={3}
-        p={5}
-        pb={4}
+        pt={parentType !== "class" ? kindToSpacing[kind] : 2}
+        pb={parentType !== "class" ? kindToSpacing[kind] - 1 : 1}
+        pl={5}
         pr={3}
         mt={1}
         mb={1}
@@ -136,7 +149,9 @@ const ReferenceNodeSelf = ({
       {baseClasses && baseClasses.length > 0 && (
         <BaseClasses value={baseClasses} />
       )}
-      <DocString fontWeight="normal" value={docStringFirstParagraph ?? ""} />
+      {docStringFirstParagraph && (
+        <DocString fontWeight="normal" value={docStringFirstParagraph ?? ""} />
+      )}
       {(hasDocStringDetail || hasSignatureDetail) && (
         <>
           {hasDocStringDetail && (
@@ -188,7 +203,12 @@ const ReferenceNodeChildren = ({
                   {groupHeading(intl, kind, childKind)}
                 </Text>
                 {groupedChildren?.get(childKind as any)?.map((c) => (
-                  <ReferenceNode anchor={anchor} key={c.id} docs={c} />
+                  <ReferenceNode
+                    anchor={anchor}
+                    key={c.id}
+                    docs={c}
+                    parentType={docs.kind}
+                  />
                 ))}
               </Box>
             )

--- a/src/documentation/reference/ReferenceNode.tsx
+++ b/src/documentation/reference/ReferenceNode.tsx
@@ -38,13 +38,6 @@ const kindToHeading: Record<string, any> = {
   function: "h4",
 };
 
-const kindToSpacing: Record<string, any> = {
-  module: 5,
-  class: 5,
-  variable: 3,
-  function: 3,
-};
-
 export const classToInstanceMap: Record<string, string> = {
   Button: "button_a",
   MicroBitDigitalPin: "pin0",
@@ -59,7 +52,7 @@ interface ApiDocEntryNodeProps extends BoxProps {
 }
 
 const ReferenceNode = ({ anchor, docs, ...props }: ApiDocEntryNodeProps) => {
-  const { id, kind } = docs;
+  const { id } = docs;
 
   // Numeric suffixes are used for overrides but links may omit them when
   // a specific override is not known and we should match the first only.
@@ -77,7 +70,7 @@ const ReferenceNode = ({ anchor, docs, ...props }: ApiDocEntryNodeProps) => {
         fontSize="sm"
         spacing={3}
         p={5}
-        pb={3}
+        pb={4}
         pr={3}
         mt={1}
         mb={1}

--- a/src/documentation/reference/ReferenceToolkit.tsx
+++ b/src/documentation/reference/ReferenceToolkit.tsx
@@ -74,7 +74,7 @@ const ActiveToolkitLevel = ({
         <List flex="1 1 auto">
           {(module.children ?? []).map((child) => (
             <ListItem key={child.id}>
-              <ReferenceNode docs={child} width="100%" anchor={anchor} mb={0} />
+              <ReferenceNode docs={child} width="100%" anchor={anchor} />
               <Divider />
             </ListItem>
           ))}


### PR DESCRIPTION
Adjust reference toolkit spacing to reduce excess space and ensure highlight on scrolling looks sensible.