### PR TITLE
Fix URLs on navigation

### DIFF
--- a/src/documentation/explore/ToolkitContent.tsx
+++ b/src/documentation/explore/ToolkitContent.tsx
@@ -36,14 +36,13 @@ const getAspectRatio = (imageRef: string): number | undefined => {
 };
 
 const ToolkitApiLinkMark = (props: SerializerMarkProps<ToolkitApiLink>) => {
-  const [state, setState] = useRouterState();
+  const [, setState] = useRouterState();
   return (
     <Link
       color="brand.600"
       onClick={(e) => {
         e.preventDefault();
         setState({
-          ...state,
           tab: "reference",
           reference: { id: props.mark.name },
         });

--- a/src/editor/codemirror/CodeMirror.tsx
+++ b/src/editor/codemirror/CodeMirror.tsx
@@ -181,7 +181,6 @@ const CodeMirror = ({
       const id = (event as CustomEvent).detail.id;
       setRouterState(
         {
-          ...routerState,
           tab: "reference",
           reference: { id },
         },


### PR DESCRIPTION
Fix for tangled URLs on navigation from signature help and explore tab into reference tab while explore tab open.

Closes #510.