### PR TITLE
Tweak min width.

### DIFF
--- a/src/workbench/Workbench.tsx
+++ b/src/workbench/Workbench.tsx
@@ -23,7 +23,7 @@ import SerialArea from "../serial/SerialArea";
 import SideBar from "./SideBar";
 import { useSelection } from "./use-selection";
 
-const minimums: [number, number] = [380, 580];
+const minimums: [number, number] = [420, 580];
 
 /**
  * The main app layout with resizable panels.


### PR DESCRIPTION
This needs a more responsive solution, but it needs to be split pane
aware. Going with this for now to avoid broken UI in user testing.

Closes https://github.com/microbit-foundation/python-editor-next/issues/502