### PR TITLE
Code embed: remove pop-up code in favour of z-index

### DIFF
--- a/src/documentation/explore/CodeEmbed.tsx
+++ b/src/documentation/explore/CodeEmbed.tsx
@@ -60,12 +60,12 @@ const CodeEmbed = ({ code: codeWithImports }: CodeEmbedProps) => {
   const codeHeight = `calc(${textHeight} + var(--chakra-space-2) + var(--chakra-space-2))`;
   const [codeTop, setCodeTop] = useState<string | undefined>(undefined);
   const enterRaisedState = useCallback(() => {
-    setState("raised");
     setCodeTop(codeRef.current!.getBoundingClientRect().top + "px");
+    setState("raised");
   }, [setState]);
   const clearRaisedState = useCallback(() => {
-    setState("default");
     setCodeTop(undefined);
+    setState("default");
   }, [setState]);
   const handleInsertCode = useCallback(
     () => actions?.insertCode(codeWithImports),
@@ -87,7 +87,7 @@ const CodeEmbed = ({ code: codeWithImports }: CodeEmbedProps) => {
       <Box
         height={codeHeight}
         fontSize="md"
-        position={codeTop ? "static" : "relative"}
+        position={codeTop ? undefined : "relative"}
       >
         <Code
           onMouseEnter={enterRaisedState}

--- a/src/documentation/explore/ExploreToolkit.tsx
+++ b/src/documentation/explore/ExploreToolkit.tsx
@@ -89,6 +89,7 @@ const ActiveToolkitLevel = ({
             <ToolkitContent content={topic.introduction} />
           </Box>
         )}
+
         <List flex="1 1 auto">
           {topic.contents?.map((item) => (
             <ListItem key={item.name}>
@@ -98,6 +99,7 @@ const ActiveToolkitLevel = ({
                 anchor={anchor}
                 active={activeItem === item}
               />
+
               <Divider />
             </ListItem>
           ))}

--- a/src/documentation/explore/Slide.tsx
+++ b/src/documentation/explore/Slide.tsx
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { motion, Spring, useReducedMotion } from "framer-motion";
+import { useRef } from "react";
 
 const transition: Spring = {
   type: "spring",
@@ -19,6 +20,11 @@ const animations = {
     animate: {
       x: 0,
       transition,
+      // Workaround. Avoid non-none transform remaining in the DOM which affects stacking contexts
+      // https://github.com/framer/motion/issues/823
+      transitionEnd: {
+        x: 0,
+      },
     },
   },
   forward: {
@@ -28,14 +34,18 @@ const animations = {
     animate: {
       x: 0,
       transition,
+      // See workaround note above.
+      transitionEnd: {
+        x: 0,
+      },
     },
   },
   none: {
     initial: {
-      x: 0,
+      x: "unset",
     },
     animate: {
-      x: 0,
+      x: "unset",
     },
   },
 };
@@ -48,10 +58,12 @@ const Slide = ({
   children: JSX.Element;
 }) => {
   const reducedMotion = useReducedMotion();
+  const ref = useRef<HTMLDivElement>(null);
   return reducedMotion ? (
     children
   ) : (
     <motion.div
+      ref={ref}
       initial={animations[direction].initial}
       animate={animations[direction].animate}
     >

--- a/src/documentation/explore/ToolkitTopicEntry.tsx
+++ b/src/documentation/explore/ToolkitTopicEntry.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { Flex, Stack, Text, Box } from "@chakra-ui/layout";
+import { Flex, Stack, Text } from "@chakra-ui/layout";
 import { Collapse, useDisclosure } from "@chakra-ui/react";
 import { Select } from "@chakra-ui/select";
 import { ChangeEvent, useCallback, useState } from "react";

--- a/src/documentation/explore/ToolkitTopicEntry.tsx
+++ b/src/documentation/explore/ToolkitTopicEntry.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { Flex, Stack, Text } from "@chakra-ui/layout";
+import { Flex, Stack, Text, Box } from "@chakra-ui/layout";
 import { Collapse, useDisclosure } from "@chakra-ui/react";
 import { Select } from "@chakra-ui/select";
 import { ChangeEvent, useCallback, useState } from "react";

--- a/src/workbench/ScrollablePanel.tsx
+++ b/src/workbench/ScrollablePanel.tsx
@@ -33,14 +33,7 @@ const ScrollablePanel = ({ children }: ScrollablePanelProps) => {
   const ref = useRef<HTMLDivElement>(null);
 
   return (
-    <Box
-      ref={ref}
-      flex="1 0 auto"
-      overflowY="auto"
-      overflowX="hidden"
-      height={0}
-      position="relative"
-    >
+    <Box ref={ref} flex="1 0 auto" overflowY="auto" height={0}>
       <ScrollablePanelContext.Provider value={ref}>
         {children}
       </ScrollablePanelContext.Provider>

--- a/src/workbench/SideBarTab.tsx
+++ b/src/workbench/SideBarTab.tsx
@@ -30,7 +30,6 @@ const SideBarTab = ({
       height={width}
       width={width}
       p={0}
-      position="relative"
       className="sidebar-tab" // Used for custom outline below
       onClick={handleTabClick}
       mb={mb ? mb : 0}


### PR DESCRIPTION
This needs more testing before I'm confident it's the right direction, in particular I've focussed at 

I also clear the pop-up on scroll which seems to fix the sticky pop-ups on scroll issue.

You still can't scroll when dwelling over a pop-up. I'm not really sure why. It seems like this might be unavoidable.