### PR TITLE
Logging fixes

### DIFF
--- a/src/documentation/explore/CodeEmbed.tsx
+++ b/src/documentation/explore/CodeEmbed.tsx
@@ -188,7 +188,7 @@ const Code = forwardRef<CodeProps, "pre">(
       (event: React.DragEvent) => {
         logging.event({
           type: "code-drag",
-          detail: parentSlug,
+          message: parentSlug,
         });
         dndDebug("dragstart");
         event.dataTransfer.dropEffect = "copy";

--- a/src/documentation/reference/ReferenceNode.tsx
+++ b/src/documentation/reference/ReferenceNode.tsx
@@ -355,7 +355,7 @@ const DraggableSignature = ({
     (event: React.DragEvent) => {
       logging.event({
         type: "code-drag",
-        detail: id,
+        message: id,
       });
       dndDebug("dragstart");
       event.dataTransfer.dropEffect = "copy";

--- a/src/editor/active-editor-hooks.tsx
+++ b/src/editor/active-editor-hooks.tsx
@@ -31,7 +31,7 @@ export class EditorActions {
   insertCode = (code: string, id?: string): void => {
     this.logging.event({
       type: "code-insert",
-      detail: id,
+      message: id,
     });
     this.view.dispatch(calculateChanges(this.view.state, code, "example"));
     this.view.focus();

--- a/src/editor/codemirror/dnd.ts
+++ b/src/editor/codemirror/dnd.ts
@@ -176,7 +176,7 @@ const dndHandlers = () => {
         }
         deployment.logging.event({
           type: "code-drop",
-          detail: dragContext.id,
+          message: dragContext.id,
         });
         debug("  drop");
         clearSuppressChildDragEnterLeave(view);

--- a/src/project/project-actions.tsx
+++ b/src/project/project-actions.tsx
@@ -389,10 +389,6 @@ export class ProjectActions {
    * Create a file, prompting the user for the name.
    */
   createFile = async () => {
-    this.logging.event({
-      type: "create-file",
-    });
-
     const preexistingFiles = new Set(this.fs.project.files.map((f) => f.name));
     const validate = (filename: string) =>
       validateNewFilename(filename, (f) => preexistingFiles.has(f), this.intl);
@@ -406,6 +402,9 @@ export class ProjectActions {
     });
 
     if (filenameWithoutExtension) {
+      this.logging.event({
+        type: "create-file",
+      });
       try {
         const filename = ensurePythonExtension(filenameWithoutExtension);
         await this.fs.write(

--- a/src/router-hooks.tsx
+++ b/src/router-hooks.tsx
@@ -121,7 +121,7 @@ export const RouterProvider = ({ children }: { children: ReactNode }) => {
       if (source) {
         logging.event({
           type: source,
-          detail: newState.explore?.id || newState.reference?.id,
+          message: newState.explore?.id || newState.reference?.id,
         });
       }
       const url = toUrl(newState);


### PR DESCRIPTION
Change some logging events to use `message` instead of `detail` for analytics. 

Move logging event for `create-file` so it only fires when a file is created, not when the dialog is opened.

See #493.