### PR TITLE
Improve navigation highlight

### DIFF
--- a/src/documentation/reference/ReferenceNode.tsx
+++ b/src/documentation/reference/ReferenceNode.tsx
@@ -87,7 +87,7 @@ const ReferenceNode = ({
         pt={kindToSpacing[kind] - (parentType === "class" ? 1 : 0)}
         pb={kindToSpacing[kind] - (parentType === "class" ? 2 : 1)}
         pl={5}
-        pr={3}
+        pr={0}
         mt={1}
         mb={1}
         {...props}
@@ -131,7 +131,7 @@ const ReferenceNodeSelf = ({
     docStringRemainder && docStringRemainder.length > 0;
 
   return (
-    <VStack alignItems="stretch" spacing={3}>
+    <VStack alignItems="stretch" spacing={3} pr={3}>
       {kind === "function" || kind === "variable" ? (
         <DraggableSignature
           signature={signature}


### PR DESCRIPTION
This prevents a gap between the Highlight element and the scroll bar (see below) for class methods/fields in the reference documentation.

![image](https://user-images.githubusercontent.com/95928279/152504550-3fecfe22-acb7-417a-8f1b-21f9c032c7ec.png)
