### PR TITLE
Fix search results navigation

### DIFF
--- a/src/workbench/SideBarHeader.tsx
+++ b/src/workbench/SideBarHeader.tsx
@@ -107,7 +107,16 @@ const SideBarHeader = () => {
         setViewedResults([...viewedResults, id]);
       }
       searchModal.onClose();
-      setRouterState(navigation, "toolkit-search");
+      // Create new RouterState object to enforce navigation when clicking the same entry twice.
+      const routerState: RouterState = {
+        tab: navigation.tab,
+      };
+      if (navigation.explore?.id) {
+        routerState.explore = { id: navigation.explore.id };
+      } else if (navigation.reference?.id) {
+        routerState.reference = { id: navigation.reference.id };
+      }
+      setRouterState(routerState, "toolkit-search");
     },
     [setViewedResults, viewedResults, searchModal, setRouterState]
   );

--- a/src/workbench/SideBarHeader.tsx
+++ b/src/workbench/SideBarHeader.tsx
@@ -108,14 +108,7 @@ const SideBarHeader = () => {
       }
       searchModal.onClose();
       // Create new RouterState object to enforce navigation when clicking the same entry twice.
-      const routerState: RouterState = {
-        tab: navigation.tab,
-      };
-      if (navigation.explore?.id) {
-        routerState.explore = { id: navigation.explore.id };
-      } else if (navigation.reference?.id) {
-        routerState.reference = { id: navigation.reference.id };
-      }
+      const routerState: RouterState = JSON.parse(JSON.stringify(navigation));
       setRouterState(routerState, "toolkit-search");
     },
     [setViewedResults, viewedResults, searchModal, setRouterState]


### PR DESCRIPTION
Clicking same entry twice in a row (or more) now results in the correct navigation behaviour.

Closes #535.