### PR TITLE
Retry async imports.

### DIFF
--- a/src/common/chunk-util.test.ts
+++ b/src/common/chunk-util.test.ts
@@ -1,0 +1,30 @@
+import { retryAsyncLoad } from "./chunk-util";
+
+describe("retryAsyncLoad", () => {
+  it("retry, fail", async () => {
+    const waitTimes: number[] = [];
+    const waiter = (waitTime: number) => {
+      waitTimes.push(waitTime);
+      return Promise.resolve();
+    };
+    await expect(() =>
+      retryAsyncLoad(async () => {
+        throw new Error("oops");
+      }, waiter)
+    ).rejects.toThrow("oops");
+    expect(waitTimes).toEqual([250, 750, 2250, 6750]);
+  });
+  it("retry, pass", async () => {
+    const waiter = () => Promise.resolve();
+    let i = 0;
+    expect(
+      await retryAsyncLoad(async () => {
+        if (i === 4) {
+          return "yay";
+        }
+        i++;
+        throw new Error("oops");
+      }, waiter)
+    ).toEqual("yay");
+  });
+});

--- a/src/common/chunk-util.ts
+++ b/src/common/chunk-util.ts
@@ -1,0 +1,23 @@
+const defaultWaiter = (waitTime: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, waitTime));
+
+export const retryAsyncLoad = async <T>(
+  load: () => Promise<T>,
+  waiter: (waitTime: number) => Promise<void> = defaultWaiter
+): Promise<T> => {
+  let waitTime = 250;
+  let attempts = 0;
+  while (true) {
+    try {
+      // Must await here!
+      return await load();
+    } catch (e) {
+      if (attempts === 4) {
+        throw e;
+      }
+      await waiter(waitTime);
+      attempts++;
+      waitTime *= 3;
+    }
+  }
+};

--- a/src/documentation/search/search.ts
+++ b/src/documentation/search/search.ts
@@ -5,6 +5,7 @@
  */
 import lunr from "lunr";
 import stemmerSupport from "lunr-languages/lunr.stemmer.support";
+import { retryAsyncLoad } from "../../common/chunk-util";
 import { firstParagraph } from "../../editor/codemirror/language-server/docstrings";
 import type {
   ApiDocsEntry,
@@ -219,7 +220,9 @@ export const buildToolkitIndex = async (
   referenceToolkit: ApiDocsResponse
 ): Promise<LunrSearch> => {
   const language = exploreToolkit.language;
-  const languageSupport = await loadLunrLanguageSupport(language);
+  const languageSupport = await retryAsyncLoad(() =>
+    loadLunrLanguageSupport(language)
+  );
   const plugins: lunr.Builder.Plugin[] = [];
   if (languageSupport) {
     // Loading plugin for fr makes lunr.fr available but we don't model this in the types.

--- a/src/language-server/pyright.ts
+++ b/src/language-server/pyright.ts
@@ -8,6 +8,7 @@ import {
   BrowserMessageReader,
   BrowserMessageWriter,
 } from "vscode-jsonrpc/browser";
+import { retryAsyncLoad } from "../common/chunk-util";
 import { createUri, LanguageServerClient } from "./client";
 
 // This is modified by bin/update-pyright.sh
@@ -65,7 +66,7 @@ export const pyright = (): LanguageServerClient | undefined => {
   const client = new LanguageServerClient(connection, {
     rootUri: createUri(""),
     initializationOptions: async () => {
-      const typeshed = await import("./typeshed.json");
+      const typeshed = await retryAsyncLoad(() => import("./typeshed.json"));
       return {
         files: typeshed,
       };

--- a/src/messages/TranslationProvider.tsx
+++ b/src/messages/TranslationProvider.tsx
@@ -6,6 +6,7 @@
 import { useSettings } from "../settings/settings";
 import { IntlProvider, MessageFormatElement } from "react-intl";
 import { ReactNode, useEffect, useState } from "react";
+import { retryAsyncLoad } from "../common/chunk-util";
 
 async function loadLocaleData(locale: string) {
   switch (locale) {
@@ -33,7 +34,7 @@ const TranslationProvider = ({ children }: TranslationProviderProps) => {
   const [messages, setMessages] = useState<Messages | undefined>();
   useEffect(() => {
     const load = async () => {
-      setMessages(await loadLocaleData(languageId));
+      setMessages(await retryAsyncLoad(() => loadLocaleData(languageId)));
     };
     load();
   }, [languageId]);


### PR DESCRIPTION
A more general solution would be good.

The use of this should be clear from Sentry and I think I'm happy to drive future work on this from Sentry feedback rather than do more now.