### PR TITLE
Avoid a mix of system and custom colours here.

### DIFF
--- a/src/editor/codemirror/themeExtensions.ts
+++ b/src/editor/codemirror/themeExtensions.ts
@@ -62,9 +62,8 @@ export const themeExtensions = (fontSize: string) => {
       border: "1px solid var(--chakra-colors-gray-400)",
     },
     ".cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected]": {
-      // Matches the text selection colour from the default CM theme.
-      // We might like to change both if we add a lighter brand color.
       background: "#d7d4f0",
+      color: "var(--chakra-colors-gray-800)",
     },
     ".cm-tooltip.cm-completionInfo.cm-completionInfo-right": {
       borderLeft: "none",


### PR DESCRIPTION
On Windows (at least for @microbit-robert) the selected autocomplete item was white which has poor contrast.