### PR TITLE
Fix traceback name and link for v1

### DIFF
--- a/src/device/device-hooks.test.tsx
+++ b/src/device/device-hooks.test.tsx
@@ -136,4 +136,23 @@ SomeError:
     traceback = tsb.push(toCrLf("0".repeat(5000)))!;
     expect(traceback).toBeUndefined();
   });
+
+  it("provides the correct main file name for V1 and V2 boards", () => {
+    const tsb = new TracebackScrollback();
+    // Entry/main file is __main__ for V1 boards
+    const tracebackV1 = tsb.push(
+      toCrLf(`Traceback (most recent call last):
+  File "__main__", line 6, in <module>
+NameError: name 'foo' is not defined`)
+    )!;
+    expect(tracebackV1.file).toBe("main.py");
+
+    // Entry/main file is main.py for V2 boards
+    const tracebackV2 = tsb.push(
+      toCrLf(`Traceback (most recent call last):
+  File "main.py", line 6, in <module>
+NameError: name 'foo' is not defined`)
+    )!;
+    expect(tracebackV2.file).toBe("main.py");
+  });
 });

--- a/src/device/device-hooks.ts
+++ b/src/device/device-hooks.ts
@@ -70,7 +70,8 @@ export const parseTraceLine = (line: string): TraceLineParts => {
   // File "<stdin>", line 1, in <module>
   const match = /^File [<"]([^>"]+)[">], line (\d+)/.exec(line.trim());
   if (match) {
-    let file: string | undefined = match[1];
+    const file: string | undefined =
+      match[1] === "__main__" ? "main.py" : match[1];
     let line: number | undefined;
     const number = match[2];
     if (number) {


### PR DESCRIPTION
Fixes the traceback name and link for v1 boards where the error occurs in the `main` file.

Closes #571.