### PR TITLE
Remove unneeded height to fix Safari.

### DIFF
--- a/src/workbench/AboutDialog/AboutDialog.tsx
+++ b/src/workbench/AboutDialog/AboutDialog.tsx
@@ -140,12 +140,7 @@ const AboutDialog = ({ isOpen, onClose }: AboutDialogProps) => {
                     />
                   </AspectRatio>
                 </Box>
-                <VStack
-                  alignItems="center"
-                  justifyContent="center"
-                  height="100%"
-                  spacing={4}
-                >
+                <VStack alignItems="center" justifyContent="center" spacing={4}>
                   <Table size="sm">
                     <Tbody>
                       {versionInfo.map((v) => (


### PR DESCRIPTION
Safari seems to use the modal height (or some similarly sized element)
here pushing the content out of the modal.

Closes https://github.com/microbit-foundation/python-editor-next/issues/578