### PR TITLE
Fix text drag inside editor

### DIFF
--- a/src/common/FileDropTarget.tsx
+++ b/src/common/FileDropTarget.tsx
@@ -36,9 +36,9 @@ const FileDropTarget = ({
     [onFileDrop]
   );
   const handleDragOver = useCallback((event: React.DragEvent<HTMLElement>) => {
-    event.preventDefault();
     const hasFile = Array.from(event.dataTransfer.types).indexOf("Files") >= 0;
     if (hasFile) {
+      event.preventDefault();
       setDragOver(true);
       event.dataTransfer.dropEffect = "copy";
     }


### PR DESCRIPTION
Only prevent default behaviour when the drag event contains files so that default CodeMirror behaviour is preserved when dragging and dropping text into and within the editor.

See #449.