### PR TITLE
Full structure highlight uses lines for all blocks

### DIFF
--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -99,9 +99,9 @@ export const codeStructureSettings = (
       return {
         shape: "l-shape",
         background: "block",
-        borders: "none",
+        borders: "left-edge-only",
         cursorBackground: true,
-        cursorBorder: "left-edge-only",
+        cursorBorder: "none",
       };
   }
 };


### PR DESCRIPTION
"Full" structure highlight uses lines for all blocks. Active block marked by darker background colour.

Closes #587.