### PR TITLE
Menus always appear above hovered code examples

### DIFF
--- a/src/common/zIndex.ts
+++ b/src/common/zIndex.ts
@@ -1,7 +1,8 @@
 /**
- * (c) 2021, Micro:bit Educational Foundation and contributors
+ * (c) 2022, Micro:bit Educational Foundation and contributors
  *
  * SPDX-License-Identifier: MIT
  */
+export const zIndexCodePopUp = 2;
 // z-index above the xterm.js's layers (currently 10 but given some margin for increases as it can vary with config)
 export const zIndexAboveTerminal = 20;

--- a/src/documentation/explore/CodeEmbed.tsx
+++ b/src/documentation/explore/CodeEmbed.tsx
@@ -11,11 +11,12 @@ import { Ref, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { RiDownloadFill } from "react-icons/ri";
 import { FormattedMessage } from "react-intl";
 import { pythonSnippetMediaType } from "../../common/mediaTypes";
+import { useScrollablePanelAncestor } from "../../common/ScrollablePanel";
+import { zIndexCodePopUp } from "../../common/zIndex";
 import { useActiveEditorActions } from "../../editor/active-editor-hooks";
 import CodeMirrorView from "../../editor/codemirror/CodeMirrorView";
 import { debug as dndDebug, setDragContext } from "../../editor/codemirror/dnd";
 import { useLogging } from "../../logging/logging-hooks";
-import { useScrollablePanelAncestor } from "../../common/ScrollablePanel";
 import DragHandle from "../common/DragHandle";
 import { useCodeDragImage } from "../documentation-hooks";
 
@@ -161,7 +162,7 @@ const CodePopUp = ({ concise, full, parentSlug, ...props }: CodePopUpProps) => {
   return (
     <Portal>
       <Code
-        zIndex={2}
+        zIndex={zIndexCodePopUp}
         concise={concise}
         full={full}
         position="absolute"

--- a/src/settings/SettingsMenu.tsx
+++ b/src/settings/SettingsMenu.tsx
@@ -1,5 +1,5 @@
 /**
- * (c) 2021, Micro:bit Educational Foundation and contributors
+ * (c) 2022, Micro:bit Educational Foundation and contributors
  *
  * SPDX-License-Identifier: MIT
  */
@@ -17,6 +17,7 @@ import {
 import { IoMdGlobe } from "react-icons/io";
 import { RiListSettingsLine, RiSettings2Line } from "react-icons/ri";
 import { FormattedMessage, useIntl } from "react-intl";
+import { zIndexAboveTerminal } from "../common/zIndex";
 import { LanguageDialog } from "./LanguageDialog";
 import { SettingsDialog } from "./SettingsDialog";
 
@@ -54,7 +55,7 @@ const SettingsMenu = ({ size, ...props }: SettingsMenuProps) => {
           isRound
         />
         <Portal>
-          <MenuList zIndex={3}>
+          <MenuList zIndex={zIndexAboveTerminal}>
             <MenuItem
               icon={<IoMdGlobe />}
               onClick={languageDisclosure.onOpen}

--- a/src/settings/SettingsMenu.tsx
+++ b/src/settings/SettingsMenu.tsx
@@ -54,7 +54,7 @@ const SettingsMenu = ({ size, ...props }: SettingsMenuProps) => {
           isRound
         />
         <Portal>
-          <MenuList>
+          <MenuList zIndex={3}>
             <MenuItem
               icon={<IoMdGlobe />}
               onClick={languageDisclosure.onOpen}

--- a/src/workbench/HelpMenu.tsx
+++ b/src/workbench/HelpMenu.tsx
@@ -52,7 +52,7 @@ const HelpMenu = ({ size, ...props }: HelpMenuProps) => {
           isRound
         />
         <Portal>
-          <MenuList>
+          <MenuList zIndex={3}>
             <MenuItem
               as="a"
               href="https://microbit-micropython.readthedocs.io/en/v2-docs/"

--- a/src/workbench/HelpMenu.tsx
+++ b/src/workbench/HelpMenu.tsx
@@ -1,5 +1,5 @@
 /**
- * (c) 2021, Micro:bit Educational Foundation and contributors
+ * (c) 2022, Micro:bit Educational Foundation and contributors
  *
  * SPDX-License-Identifier: MIT
  */
@@ -20,9 +20,10 @@ import {
   RiInformationLine,
   RiQuestionLine,
 } from "react-icons/ri";
+import { FormattedMessage, useIntl } from "react-intl";
+import { zIndexAboveTerminal } from "../common/zIndex";
 import { deployment } from "../deployment";
 import AboutDialog from "./AboutDialog/AboutDialog";
-import { FormattedMessage, useIntl } from "react-intl";
 
 interface HelpMenuProps extends ThemingProps<"Menu"> {
   size?: ThemeTypings["components"]["Button"]["sizes"];
@@ -52,7 +53,7 @@ const HelpMenu = ({ size, ...props }: HelpMenuProps) => {
           isRound
         />
         <Portal>
-          <MenuList zIndex={3}>
+          <MenuList zIndex={zIndexAboveTerminal}>
             <MenuItem
               as="a"
               href="https://microbit-micropython.readthedocs.io/en/v2-docs/"


### PR DESCRIPTION
Prevents code pop overs from blocking open menus using z-index..

Closes #582.