### PR TITLE
Disable auto fix-ups for the new file input dialog.

### DIFF
--- a/src/project/NewFileNameQuestion.tsx
+++ b/src/project/NewFileNameQuestion.tsx
@@ -43,6 +43,10 @@ const NewFileNameQuestion = ({
           setValue(value);
           setError(validate(value));
         }}
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck="false"
       ></Input>
       <FormHelperText color="gray.700">
         <FormattedMessage


### PR DESCRIPTION
Closes https://github.com/microbit-foundation/python-editor-next/issues/605

None of the automatic behaviours seem useful for file names that may well be abbreviations/contractions/technical terms etc.