### PR TITLE
Signature help option and keyboard shortcuts

### DIFF
--- a/bin/tidy-lang.js
+++ b/bin/tidy-lang.js
@@ -6,6 +6,7 @@ const fs = require("fs");
 const path = require("path");
 
 const en = JSON.parse(fs.readFileSync("lang/en.json"));
+const validKeys = new Set(Object.keys(en));
 
 fs.readdirSync("lang")
   .filter((f) => f.endsWith(".json"))
@@ -16,6 +17,11 @@ fs.readdirSync("lang")
       ...en,
       ...JSON.parse(fs.readFileSync(file)),
     };
+    Object.keys(data).forEach((k) => {
+      if (!validKeys.has(k)) {
+        delete data[k];
+      }
+    });
     const sortedKeys = Object.keys(data).sort();
     const result = Object.create(null);
     sortedKeys.forEach((k) => (result[k] = data[k]));

--- a/lang/en.json
+++ b/lang/en.json
@@ -375,17 +375,17 @@
     "defaultMessage": "Options",
     "description": "Label for an options menu"
   },
-  "parameter-hints": {
-    "defaultMessage": "Parameter hints",
+  "parameter-help": {
+    "defaultMessage": "Parameter help",
     "description": "Setting label to control whether pop-up documentation for function/method parameters is automatically shown."
   },
-  "parameter-hints-automatic": {
+  "parameter-help-automatic": {
     "defaultMessage": "Automatic",
-    "description": "Parameter hints setting for when the parameter documentation is shown automatically"
+    "description": "Parameter help setting for when the parameter documentation is shown automatically"
   },
-  "parameter-hints-manual": {
+  "parameter-help-manual": {
     "defaultMessage": "Manual ({shortcut})",
-    "description": "Parameter hints setting for when the user must press a key combination to open the parameter documentation"
+    "description": "Parameter help setting for when the user must press a key combination to open the parameter documentation"
   },
   "permanently-delete": {
     "defaultMessage": "Permanently delete {filename}?",

--- a/lang/en.json
+++ b/lang/en.json
@@ -375,6 +375,18 @@
     "defaultMessage": "Options",
     "description": "Label for an options menu"
   },
+  "parameter-hints": {
+    "defaultMessage": "Parameter hints",
+    "description": "Setting label to control whether pop-up documentation for function/method parameters is automatically shown."
+  },
+  "parameter-hints-automatic": {
+    "defaultMessage": "Automatic",
+    "description": "Parameter hints setting for when the parameter documentation is shown automatically"
+  },
+  "parameter-hints-manual": {
+    "defaultMessage": "Manual ({shortcut})",
+    "description": "Parameter hints setting for when the user must press a key combination to open the parameter documentation"
+  },
   "permanently-delete": {
     "defaultMessage": "Permanently delete {filename}?",
     "description": "Confirmation question to permanently delete file"

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -374,6 +374,18 @@
     "defaultMessage": "Options",
     "description": "Label for an options menu"
   },
+  "parameter-help": {
+    "defaultMessage": "Parameter help",
+    "description": "Setting label to control whether pop-up documentation for function/method parameters is automatically shown."
+  },
+  "parameter-help-automatic": {
+    "defaultMessage": "Automatic",
+    "description": "Parameter help setting for when the parameter documentation is shown automatically"
+  },
+  "parameter-help-manual": {
+    "defaultMessage": "Manual ({shortcut})",
+    "description": "Parameter help setting for when the user must press a key combination to open the parameter documentation"
+  },
   "parameter-hints": {
     "defaultMessage": "Parameter hints",
     "description": "Setting label to control whether pop-up documentation for function/method parameters is automatically shown."

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -386,18 +386,6 @@
     "defaultMessage": "Manual ({shortcut})",
     "description": "Parameter help setting for when the user must press a key combination to open the parameter documentation"
   },
-  "parameter-hints": {
-    "defaultMessage": "Parameter hints",
-    "description": "Setting label to control whether pop-up documentation for function/method parameters is automatically shown."
-  },
-  "parameter-hints-automatic": {
-    "defaultMessage": "Parameter hints setting for when the parameter documentation is shown automatically",
-    "description": "Automatic"
-  },
-  "parameter-hints-manual": {
-    "defaultMessage": "Parameter hints setting for when the user must press a key combination to open the parameter documentation",
-    "description": "Manual"
-  },
   "permanently-delete": {
     "defaultMessage": "Supprimer {filename} définitivement ?",
     "description": "Confirmation question to permanently delete file"

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -374,6 +374,18 @@
     "defaultMessage": "Options",
     "description": "Label for an options menu"
   },
+  "parameter-hints": {
+    "defaultMessage": "Parameter hints",
+    "description": "Setting label to control whether pop-up documentation for function/method parameters is automatically shown."
+  },
+  "parameter-hints-automatic": {
+    "defaultMessage": "Parameter hints setting for when the parameter documentation is shown automatically",
+    "description": "Automatic"
+  },
+  "parameter-hints-manual": {
+    "defaultMessage": "Parameter hints setting for when the user must press a key combination to open the parameter documentation",
+    "description": "Manual"
+  },
   "permanently-delete": {
     "defaultMessage": "Supprimer {filename} définitivement ?",
     "description": "Confirmation question to permanently delete file"

--- a/lang/lol.json
+++ b/lang/lol.json
@@ -386,18 +386,6 @@
     "defaultMessage": "Manual ({shortcut})",
     "description": "Parameter help setting for when the user must press a key combination to open the parameter documentation"
   },
-  "parameter-hints": {
-    "defaultMessage": "Parameter hints",
-    "description": "Setting label to control whether pop-up documentation for function/method parameters is automatically shown."
-  },
-  "parameter-hints-automatic": {
-    "defaultMessage": "Parameter hints setting for when the parameter documentation is shown automatically",
-    "description": "Automatic"
-  },
-  "parameter-hints-manual": {
-    "defaultMessage": "Parameter hints setting for when the user must press a key combination to open the parameter documentation",
-    "description": "Manual"
-  },
   "permanently-delete": {
     "defaultMessage": "Перманентлу делете {filename}?",
     "description": "Confirmation question to permanently delete file"
@@ -461,10 +449,6 @@
   "search": {
     "defaultMessage": "Search",
     "description": "Aria label for searching documentation"
-  },
-  "search-open": {
-    "defaultMessage": "Open search",
-    "description": "Aria label for button opening the search dialog"
   },
   "serial-collapse": {
     "defaultMessage": "Хіде серіал",

--- a/lang/lol.json
+++ b/lang/lol.json
@@ -374,6 +374,18 @@
     "defaultMessage": "Оптіонс",
     "description": "Label for an options menu"
   },
+  "parameter-hints": {
+    "defaultMessage": "Parameter hints",
+    "description": "Setting label to control whether pop-up documentation for function/method parameters is automatically shown."
+  },
+  "parameter-hints-automatic": {
+    "defaultMessage": "Parameter hints setting for when the parameter documentation is shown automatically",
+    "description": "Automatic"
+  },
+  "parameter-hints-manual": {
+    "defaultMessage": "Parameter hints setting for when the user must press a key combination to open the parameter documentation",
+    "description": "Manual"
+  },
   "permanently-delete": {
     "defaultMessage": "Перманентлу делете {filename}?",
     "description": "Confirmation question to permanently delete file"

--- a/lang/lol.json
+++ b/lang/lol.json
@@ -374,6 +374,18 @@
     "defaultMessage": "Оптіонс",
     "description": "Label for an options menu"
   },
+  "parameter-help": {
+    "defaultMessage": "Parameter help",
+    "description": "Setting label to control whether pop-up documentation for function/method parameters is automatically shown."
+  },
+  "parameter-help-automatic": {
+    "defaultMessage": "Automatic",
+    "description": "Parameter help setting for when the parameter documentation is shown automatically"
+  },
+  "parameter-help-manual": {
+    "defaultMessage": "Manual ({shortcut})",
+    "description": "Parameter help setting for when the user must press a key combination to open the parameter documentation"
+  },
   "parameter-hints": {
     "defaultMessage": "Parameter hints",
     "description": "Setting label to control whether pop-up documentation for function/method parameters is automatically shown."

--- a/src/editor/EditorContainer.tsx
+++ b/src/editor/EditorContainer.tsx
@@ -26,7 +26,7 @@ const EditorContainer = ({ selection }: EditorContainerProps) => {
       onChange={onFileChange}
       fontSize={settings.fontSize}
       codeStructureSettings={codeStructureSettings(settings)}
-      signatureHelpOption={settings.signatureHelp}
+      parameterHelpOption={settings.parameterHelp}
     />
   );
 };

--- a/src/editor/EditorContainer.tsx
+++ b/src/editor/EditorContainer.tsx
@@ -26,6 +26,7 @@ const EditorContainer = ({ selection }: EditorContainerProps) => {
       onChange={onFileChange}
       fontSize={settings.fontSize}
       codeStructureSettings={codeStructureSettings(settings)}
+      signatureHelpOption={settings.signatureHelp}
     />
   );
 };

--- a/src/editor/codemirror/CodeMirror.tsx
+++ b/src/editor/codemirror/CodeMirror.tsx
@@ -13,7 +13,7 @@ import { createUri } from "../../language-server/client";
 import { useLanguageServerClient } from "../../language-server/language-server-hooks";
 import { useLogging } from "../../logging/logging-hooks";
 import { useRouterState } from "../../router-hooks";
-import { SignatureHelpOption } from "../../settings/settings";
+import { ParameterHelpOption } from "../../settings/settings";
 import { WorkbenchSelection } from "../../workbench/use-selection";
 import {
   EditorActions,
@@ -34,7 +34,7 @@ interface CodeMirrorProps {
   selection: WorkbenchSelection;
   fontSize: number;
   codeStructureSettings: CodeStructureSettings;
-  signatureHelpOption: SignatureHelpOption;
+  parameterHelpOption: ParameterHelpOption;
 }
 
 /**
@@ -52,7 +52,7 @@ const CodeMirror = ({
   selection,
   fontSize,
   codeStructureSettings,
-  signatureHelpOption,
+  parameterHelpOption,
 }: CodeMirrorProps) => {
   // Really simple model for now as we only have one editor at a time.
   const [, setActiveEditor] = useActiveEditorActionsState();
@@ -77,9 +77,9 @@ const CodeMirror = ({
     () => ({
       fontSize,
       codeStructureSettings,
-      signatureHelpOption,
+      parameterHelpOption,
     }),
-    [fontSize, codeStructureSettings, signatureHelpOption]
+    [fontSize, codeStructureSettings, parameterHelpOption]
   );
 
   useEffect(() => {
@@ -107,7 +107,9 @@ const CodeMirror = ({
           compartment.of([
             client
               ? languageServer(client, uri, intl, logging, {
-                  signatureHelp: signatureHelpOption,
+                  signatureHelp: {
+                    automatic: parameterHelpOption === "automatic",
+                  },
                 })
               : [],
             codeStructure(options.codeStructureSettings),
@@ -132,7 +134,7 @@ const CodeMirror = ({
     options,
     setActiveEditor,
     setEditorInfo,
-    signatureHelpOption,
+    parameterHelpOption,
     uri,
   ]);
   useEffect(() => {
@@ -152,7 +154,9 @@ const CodeMirror = ({
         compartment.reconfigure([
           client
             ? languageServer(client, uri, intl, logging, {
-                signatureHelp: signatureHelpOption,
+                signatureHelp: {
+                  automatic: parameterHelpOption === "automatic",
+                },
               })
             : [],
           codeStructure(options.codeStructureSettings),
@@ -160,7 +164,7 @@ const CodeMirror = ({
         ]),
       ],
     });
-  }, [options, signatureHelpOption, client, intl, logging, uri]);
+  }, [options, parameterHelpOption, client, intl, logging, uri]);
 
   const { location } = selection;
   useEffect(() => {

--- a/src/editor/codemirror/CodeMirror.tsx
+++ b/src/editor/codemirror/CodeMirror.tsx
@@ -13,6 +13,7 @@ import { createUri } from "../../language-server/client";
 import { useLanguageServerClient } from "../../language-server/language-server-hooks";
 import { useLogging } from "../../logging/logging-hooks";
 import { useRouterState } from "../../router-hooks";
+import { SignatureHelpOption } from "../../settings/settings";
 import { WorkbenchSelection } from "../../workbench/use-selection";
 import {
   EditorActions,
@@ -20,13 +21,9 @@ import {
   useActiveEditorInfoState,
 } from "../active-editor-hooks";
 import "./CodeMirror.css";
-import { editorConfig, themeExtensionsCompartment } from "./config";
+import { compartment, editorConfig } from "./config";
 import { languageServer } from "./language-server/view";
-import {
-  codeStructure,
-  CodeStructureSettings,
-  structureHighlightingCompartment,
-} from "./structure-highlighting";
+import { codeStructure, CodeStructureSettings } from "./structure-highlighting";
 import themeExtensions from "./themeExtensions";
 
 interface CodeMirrorProps {
@@ -37,6 +34,7 @@ interface CodeMirrorProps {
   selection: WorkbenchSelection;
   fontSize: number;
   codeStructureSettings: CodeStructureSettings;
+  signatureHelpOption: SignatureHelpOption;
 }
 
 /**
@@ -54,6 +52,7 @@ const CodeMirror = ({
   selection,
   fontSize,
   codeStructureSettings,
+  signatureHelpOption,
 }: CodeMirrorProps) => {
   // Really simple model for now as we only have one editor at a time.
   const [, setActiveEditor] = useActiveEditorActionsState();
@@ -78,8 +77,9 @@ const CodeMirror = ({
     () => ({
       fontSize,
       codeStructureSettings,
+      signatureHelpOption,
     }),
-    [fontSize, codeStructureSettings]
+    [fontSize, codeStructureSettings, signatureHelpOption]
   );
 
   useEffect(() => {
@@ -103,12 +103,16 @@ const CodeMirror = ({
           lineNumbers(),
           highlightActiveLineGutter(),
           highlightActiveLine(),
-          client ? languageServer(client, uri, intl, logging) : [],
           // Extensions we enable/disable based on props.
-          structureHighlightingCompartment.of(
-            codeStructure(options.codeStructureSettings)
-          ),
-          themeExtensionsCompartment.of(themeExtensionsForOptions(options)),
+          compartment.of([
+            client
+              ? languageServer(client, uri, intl, logging, {
+                  signatureHelp: signatureHelpOption,
+                })
+              : [],
+            codeStructure(options.codeStructureSettings),
+            themeExtensionsForOptions(options),
+          ]),
         ],
       });
       const view = new EditorView({
@@ -120,15 +124,16 @@ const CodeMirror = ({
       setActiveEditor(new EditorActions(view, logging));
     }
   }, [
-    options,
-    defaultValue,
-    onChange,
     client,
-    setActiveEditor,
-    uri,
+    defaultValue,
     intl,
-    setEditorInfo,
     logging,
+    onChange,
+    options,
+    setActiveEditor,
+    setEditorInfo,
+    signatureHelpOption,
+    uri,
   ]);
   useEffect(() => {
     // Do this separately as we don't want to destroy the view whenever options needed for initialization change.
@@ -144,15 +149,18 @@ const CodeMirror = ({
   useEffect(() => {
     viewRef.current!.dispatch({
       effects: [
-        themeExtensionsCompartment.reconfigure(
-          themeExtensionsForOptions(options)
-        ),
-        structureHighlightingCompartment.reconfigure(
-          codeStructure(options.codeStructureSettings)
-        ),
+        compartment.reconfigure([
+          client
+            ? languageServer(client, uri, intl, logging, {
+                signatureHelp: signatureHelpOption,
+              })
+            : [],
+          codeStructure(options.codeStructureSettings),
+          themeExtensionsForOptions(options),
+        ]),
       ],
     });
-  }, [options]);
+  }, [options, signatureHelpOption, client, intl, logging, uri]);
 
   const { location } = selection;
   useEffect(() => {

--- a/src/editor/codemirror/config.ts
+++ b/src/editor/codemirror/config.ts
@@ -30,7 +30,7 @@ const customTabBinding: KeyBinding = {
   shift: indentLess,
 };
 
-export const themeExtensionsCompartment = new Compartment();
+export const compartment = new Compartment();
 
 const indentSize = 4;
 export const editorConfig: Extension = [

--- a/src/editor/codemirror/language-server/signatureHelp.ts
+++ b/src/editor/codemirror/language-server/signatureHelp.ts
@@ -10,7 +10,10 @@
 import { StateEffect, StateField } from "@codemirror/state";
 import { showTooltip, Tooltip } from "@codemirror/tooltip";
 import {
+  Command,
   EditorView,
+  KeyBinding,
+  keymap,
   logException,
   PluginValue,
   ViewPlugin,
@@ -23,10 +26,11 @@ import {
   SignatureHelpParams,
   SignatureHelpRequest,
 } from "vscode-languageserver-protocol";
-import { BaseLanguageServerView } from "./common";
+import { SignatureHelpOption } from "../../../settings/settings";
+import { BaseLanguageServerView, clientFacet, uriFacet } from "./common";
 import {
-  wrapWithDocumentationButton,
   renderDocumentation,
+  wrapWithDocumentationButton,
 } from "./documentation";
 import { nameFromSignature, removeFullyQualifiedName } from "./names";
 import { offsetToPosition } from "./positions";
@@ -56,7 +60,53 @@ const signatureHelpToolTipBaseTheme = EditorView.baseTheme({
   },
 });
 
-export const signatureHelp = (intl: IntlShape) => {
+const closeSignatureHelp: Command = (view: EditorView) => {
+  // TODO: check it's open, if not return false.
+  view.dispatch({
+    effects: setSignatureHelpEffect.of({
+      pos: -1,
+      result: null,
+    }),
+  });
+  return true;
+};
+
+const triggerSignatureHelpRequest = async (view: EditorView): Promise<void> => {
+  const uri = view.state.facet(uriFacet)!;
+  const client = view.state.facet(clientFacet)!;
+  const pos = view.state.selection.main.from;
+  const params: SignatureHelpParams = {
+    textDocument: { uri },
+    position: offsetToPosition(view.state.doc, pos),
+  };
+  try {
+    const result = await client.connection.sendRequest(
+      SignatureHelpRequest.type,
+      params
+    );
+    view.dispatch({
+      effects: [setSignatureHelpEffect.of({ pos, result })],
+    });
+  } catch (e) {
+    logException(view.state, e, "signature-help");
+    view.dispatch({
+      effects: [setSignatureHelpEffect.of({ pos, result: null })],
+    });
+  }
+};
+
+const openSignatureHelp: Command = (view: EditorView) => {
+  triggerSignatureHelpRequest(view);
+  return true;
+};
+
+const signatureHelpKeymap: readonly KeyBinding[] = [
+  // This matches VS Code.
+  { key: "Mod-Shift-Space", run: openSignatureHelp },
+  { key: "Escape", run: closeSignatureHelp },
+];
+
+export const signatureHelp = (intl: IntlShape, option: SignatureHelpOption) => {
   const signatureHelpTooltipField = StateField.define<SignatureHelpState>({
     create: () => ({
       result: null,
@@ -77,16 +127,12 @@ export const signatureHelp = (intl: IntlShape) => {
     extends BaseLanguageServerView
     implements PluginValue
   {
-    constructor(view: EditorView, private intl: IntlShape) {
-      super(view);
-    }
-
     update({ docChanged, selectionSet, transactions }: ViewUpdate) {
       if (
         (docChanged || selectionSet) &&
         this.view.state.field(signatureHelpTooltipField).tooltip
       ) {
-        this.triggerSignatureHelpRequest();
+        triggerSignatureHelpRequest(this.view);
       } else if (docChanged) {
         const last = transactions[transactions.length - 1];
 
@@ -96,32 +142,10 @@ export const signatureHelp = (intl: IntlShape) => {
         if (last.isUserEvent("input") || last.isUserEvent("dnd.drop.call")) {
           last.changes.iterChanges((_fromA, _toA, _fromB, _toB, inserted) => {
             if (inserted.sliceString(0).trim().endsWith("()")) {
-              this.triggerSignatureHelpRequest();
+              triggerSignatureHelpRequest(this.view);
             }
           });
         }
-      }
-    }
-
-    async triggerSignatureHelpRequest() {
-      const pos = this.view.state.selection.main.from;
-      const params: SignatureHelpParams = {
-        textDocument: { uri: this.uri },
-        position: offsetToPosition(this.view.state.doc, pos),
-      };
-      try {
-        const result = await this.client.connection.sendRequest(
-          SignatureHelpRequest.type,
-          params
-        );
-        this.view.dispatch({
-          effects: [setSignatureHelpEffect.of({ pos, result })],
-        });
-      } catch (e) {
-        logException(this.view.state, e, "signature-help");
-        this.view.dispatch({
-          effects: [setSignatureHelpEffect.of({ pos, result: null })],
-        });
       }
     }
   }
@@ -223,8 +247,12 @@ export const signatureHelp = (intl: IntlShape) => {
   };
 
   return [
-    ViewPlugin.define((view) => new SignatureHelpView(view, intl)),
+    // View only handles automatic triggering.
+    option === "automatic"
+      ? ViewPlugin.define((view) => new SignatureHelpView(view))
+      : [],
     signatureHelpTooltipField,
     signatureHelpToolTipBaseTheme,
+    keymap.of(signatureHelpKeymap),
   ];
 };

--- a/src/editor/codemirror/language-server/signatureHelp.ts
+++ b/src/editor/codemirror/language-server/signatureHelp.ts
@@ -26,7 +26,6 @@ import {
   SignatureHelpParams,
   SignatureHelpRequest,
 } from "vscode-languageserver-protocol";
-import { SignatureHelpOption } from "../../../settings/settings";
 import { BaseLanguageServerView, clientFacet, uriFacet } from "./common";
 import {
   renderDocumentation,
@@ -105,7 +104,7 @@ const signatureHelpKeymap: readonly KeyBinding[] = [
   { key: "Escape", run: closeSignatureHelp },
 ];
 
-export const signatureHelp = (intl: IntlShape, option: SignatureHelpOption) => {
+export const signatureHelp = (intl: IntlShape, automatic: boolean) => {
   const signatureHelpTooltipField = StateField.define<SignatureHelpState>({
     create: () => ({
       result: null,
@@ -250,9 +249,7 @@ export const signatureHelp = (intl: IntlShape, option: SignatureHelpOption) => {
 
   return [
     // View only handles automatic triggering.
-    ViewPlugin.define(
-      (view) => new SignatureHelpView(view, option === "automatic")
-    ),
+    ViewPlugin.define((view) => new SignatureHelpView(view, automatic)),
     signatureHelpTooltipField,
     signatureHelpToolTipBaseTheme,
     keymap.of(signatureHelpKeymap),

--- a/src/editor/codemirror/language-server/view.ts
+++ b/src/editor/codemirror/language-server/view.ts
@@ -90,7 +90,7 @@ export function languageServer(
     uriFacet.of(uri),
     clientFacet.of(client),
     ViewPlugin.define((view) => new LanguageServerView(view)),
-    options.signatureHelp === "simple" ? signatureHelp(intl) : [],
+    signatureHelp(intl, options.signatureHelp),
     autocompletion(intl, logging),
   ];
 }

--- a/src/editor/codemirror/language-server/view.ts
+++ b/src/editor/codemirror/language-server/view.ts
@@ -10,6 +10,7 @@ import { IntlShape } from "react-intl";
 import * as LSP from "vscode-languageserver-protocol";
 import { LanguageServerClient } from "../../../language-server/client";
 import { Logging } from "../../../logging/logging";
+import { SignatureHelpOption } from "../../../settings/settings";
 import { autocompletion } from "./autocompletion";
 import { BaseLanguageServerView, clientFacet, uriFacet } from "./common";
 import { diagnosticsMapping } from "./diagnostics";
@@ -65,6 +66,10 @@ class LanguageServerView extends BaseLanguageServerView implements PluginValue {
   }
 }
 
+interface Options {
+  signatureHelp: SignatureHelpOption;
+}
+
 /**
  * Extensions that make use of a language server client.
  *
@@ -78,13 +83,14 @@ export function languageServer(
   client: LanguageServerClient,
   uri: string,
   intl: IntlShape,
-  logging: Logging
+  logging: Logging,
+  options: Options
 ) {
   return [
     uriFacet.of(uri),
     clientFacet.of(client),
     ViewPlugin.define((view) => new LanguageServerView(view)),
-    signatureHelp(intl),
+    options.signatureHelp === "simple" ? signatureHelp(intl) : [],
     autocompletion(intl, logging),
   ];
 }

--- a/src/editor/codemirror/language-server/view.ts
+++ b/src/editor/codemirror/language-server/view.ts
@@ -10,7 +10,6 @@ import { IntlShape } from "react-intl";
 import * as LSP from "vscode-languageserver-protocol";
 import { LanguageServerClient } from "../../../language-server/client";
 import { Logging } from "../../../logging/logging";
-import { SignatureHelpOption } from "../../../settings/settings";
 import { autocompletion } from "./autocompletion";
 import { BaseLanguageServerView, clientFacet, uriFacet } from "./common";
 import { diagnosticsMapping } from "./diagnostics";
@@ -67,7 +66,9 @@ class LanguageServerView extends BaseLanguageServerView implements PluginValue {
 }
 
 interface Options {
-  signatureHelp: SignatureHelpOption;
+  signatureHelp: {
+    automatic: boolean;
+  };
 }
 
 /**
@@ -90,7 +91,7 @@ export function languageServer(
     uriFacet.of(uri),
     clientFacet.of(client),
     ViewPlugin.define((view) => new LanguageServerView(view)),
-    signatureHelp(intl, options.signatureHelp),
+    signatureHelp(intl, options.signatureHelp.automatic),
     autocompletion(intl, logging),
   ];
 }

--- a/src/editor/codemirror/structure-highlighting/index.ts
+++ b/src/editor/codemirror/structure-highlighting/index.ts
@@ -7,11 +7,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { Compartment, Extension } from "@codemirror/state";
+import { Extension } from "@codemirror/state";
 import { baseTheme } from "./theme";
 import { codeStructureView } from "./view";
-
-export const structureHighlightingCompartment = new Compartment();
 
 export type CodeStructureShape = "l-shape" | "box";
 export type CodeStructureBackground = "block" | "none";

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -749,19 +749,19 @@
       "value": "Options"
     }
   ],
-  "parameter-hints": [
+  "parameter-help": [
     {
       "type": 0,
-      "value": "Parameter hints"
+      "value": "Parameter help"
     }
   ],
-  "parameter-hints-automatic": [
+  "parameter-help-automatic": [
     {
       "type": 0,
       "value": "Automatic"
     }
   ],
-  "parameter-hints-manual": [
+  "parameter-help-manual": [
     {
       "type": 0,
       "value": "Manual ("

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -749,6 +749,32 @@
       "value": "Options"
     }
   ],
+  "parameter-hints": [
+    {
+      "type": 0,
+      "value": "Parameter hints"
+    }
+  ],
+  "parameter-hints-automatic": [
+    {
+      "type": 0,
+      "value": "Automatic"
+    }
+  ],
+  "parameter-hints-manual": [
+    {
+      "type": 0,
+      "value": "Manual ("
+    },
+    {
+      "type": 1,
+      "value": "shortcut"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
   "permanently-delete": [
     {
       "type": 0,

--- a/src/messages/fr.json
+++ b/src/messages/fr.json
@@ -775,24 +775,6 @@
       "value": ")"
     }
   ],
-  "parameter-hints": [
-    {
-      "type": 0,
-      "value": "Parameter hints"
-    }
-  ],
-  "parameter-hints-automatic": [
-    {
-      "type": 0,
-      "value": "Parameter hints setting for when the parameter documentation is shown automatically"
-    }
-  ],
-  "parameter-hints-manual": [
-    {
-      "type": 0,
-      "value": "Parameter hints setting for when the user must press a key combination to open the parameter documentation"
-    }
-  ],
   "permanently-delete": [
     {
       "type": 0,

--- a/src/messages/fr.json
+++ b/src/messages/fr.json
@@ -749,6 +749,24 @@
       "value": "Options"
     }
   ],
+  "parameter-hints": [
+    {
+      "type": 0,
+      "value": "Parameter hints"
+    }
+  ],
+  "parameter-hints-automatic": [
+    {
+      "type": 0,
+      "value": "Parameter hints setting for when the parameter documentation is shown automatically"
+    }
+  ],
+  "parameter-hints-manual": [
+    {
+      "type": 0,
+      "value": "Parameter hints setting for when the user must press a key combination to open the parameter documentation"
+    }
+  ],
   "permanently-delete": [
     {
       "type": 0,

--- a/src/messages/fr.json
+++ b/src/messages/fr.json
@@ -749,6 +749,32 @@
       "value": "Options"
     }
   ],
+  "parameter-help": [
+    {
+      "type": 0,
+      "value": "Parameter help"
+    }
+  ],
+  "parameter-help-automatic": [
+    {
+      "type": 0,
+      "value": "Automatic"
+    }
+  ],
+  "parameter-help-manual": [
+    {
+      "type": 0,
+      "value": "Manual ("
+    },
+    {
+      "type": 1,
+      "value": "shortcut"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
   "parameter-hints": [
     {
       "type": 0,

--- a/src/messages/lol.json
+++ b/src/messages/lol.json
@@ -749,6 +749,24 @@
       "value": "Оптіонс"
     }
   ],
+  "parameter-hints": [
+    {
+      "type": 0,
+      "value": "Parameter hints"
+    }
+  ],
+  "parameter-hints-automatic": [
+    {
+      "type": 0,
+      "value": "Parameter hints setting for when the parameter documentation is shown automatically"
+    }
+  ],
+  "parameter-hints-manual": [
+    {
+      "type": 0,
+      "value": "Parameter hints setting for when the user must press a key combination to open the parameter documentation"
+    }
+  ],
   "permanently-delete": [
     {
       "type": 0,

--- a/src/messages/lol.json
+++ b/src/messages/lol.json
@@ -775,24 +775,6 @@
       "value": ")"
     }
   ],
-  "parameter-hints": [
-    {
-      "type": 0,
-      "value": "Parameter hints"
-    }
-  ],
-  "parameter-hints-automatic": [
-    {
-      "type": 0,
-      "value": "Parameter hints setting for when the parameter documentation is shown automatically"
-    }
-  ],
-  "parameter-hints-manual": [
-    {
-      "type": 0,
-      "value": "Parameter hints setting for when the user must press a key combination to open the parameter documentation"
-    }
-  ],
   "permanently-delete": [
     {
       "type": 0,
@@ -929,12 +911,6 @@
     {
       "type": 0,
       "value": "Search"
-    }
-  ],
-  "search-open": [
-    {
-      "type": 0,
-      "value": "Open search"
     }
   ],
   "serial-collapse": [

--- a/src/messages/lol.json
+++ b/src/messages/lol.json
@@ -749,6 +749,32 @@
       "value": "Оптіонс"
     }
   ],
+  "parameter-help": [
+    {
+      "type": 0,
+      "value": "Parameter help"
+    }
+  ],
+  "parameter-help-automatic": [
+    {
+      "type": 0,
+      "value": "Automatic"
+    }
+  ],
+  "parameter-help-manual": [
+    {
+      "type": 0,
+      "value": "Manual ("
+    },
+    {
+      "type": 1,
+      "value": "shortcut"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
   "parameter-hints": [
     {
       "type": 0,

--- a/src/settings/SelectFormControl.tsx
+++ b/src/settings/SelectFormControl.tsx
@@ -37,7 +37,7 @@ const SelectFormControl = <T extends string>({
         id={id}
         variant="outline"
         onChange={handleChange}
-        width="20ch"
+        width="28ch"
         value={value}
       >
         {options.map(({ value, label }) => (
@@ -61,11 +61,12 @@ const SelectFormControl = <T extends string>({
 export const createOptions = <T,>(
   values: T[],
   prefix: string,
-  intl: IntlShape
+  intl: IntlShape,
+  intlValues?: Record<string, any>
 ): SelectOptionValue<T>[] => {
   return values.map((value) => ({
     value,
-    label: intl.formatMessage({ id: `${prefix}-${value}` }),
+    label: intl.formatMessage({ id: `${prefix}-${value}` }, intlValues),
   }));
 };
 

--- a/src/settings/SelectFormControl.tsx
+++ b/src/settings/SelectFormControl.tsx
@@ -1,0 +1,72 @@
+import { FormControl, FormLabel, Select } from "@chakra-ui/react";
+import { ReactNode, useCallback } from "react";
+import { IntlShape } from "react-intl";
+
+export interface SelectOptionValue<T> {
+  value: T;
+  label: ReactNode;
+}
+
+interface SelectFormControlProps<T> {
+  id: string;
+  options: SelectOptionValue<T>[];
+  label: ReactNode;
+  value: T;
+  onChange: (value: T) => void;
+}
+
+const SelectFormControl = <T extends string>({
+  id,
+  options,
+  label,
+  value,
+  onChange,
+}: SelectFormControlProps<T>) => {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) =>
+      onChange(e.currentTarget!.value as T),
+    [onChange]
+  );
+
+  return (
+    <FormControl display="flex" alignItems="center">
+      <FormLabel htmlFor={id} mb="0" fontWeight="normal" flex="1 1 auto">
+        {label}
+      </FormLabel>
+      <Select
+        id={id}
+        variant="outline"
+        onChange={handleChange}
+        width="20ch"
+        value={value}
+      >
+        {options.map(({ value, label }) => (
+          <option key={value} value={value}>
+            {label}
+          </option>
+        ))}
+      </Select>
+    </FormControl>
+  );
+};
+
+/**
+ * Helper for translated option labels.
+ *
+ * @param values Values to create options for.
+ * @param prefix Prefix (no trailing '-') to use for translation keys.
+ * @param intl For translation strings.
+ * @returns Options for the given values.
+ */
+export const createOptions = <T,>(
+  values: T[],
+  prefix: string,
+  intl: IntlShape
+): SelectOptionValue<T>[] => {
+  return values.map((value) => ({
+    value,
+    label: intl.formatMessage({ id: `${prefix}-${value}` }),
+  }));
+};
+
+export default SelectFormControl;

--- a/src/settings/SettingsArea.tsx
+++ b/src/settings/SettingsArea.tsx
@@ -11,12 +11,17 @@ import {
   NumberInput,
   NumberInputField,
   NumberInputStepper,
-  Select,
   VStack,
 } from "@chakra-ui/react";
-import React, { ReactNode, useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { maximumFontSize, minimumFontSize, useSettings } from "./settings";
+import SelectFormControl, { createOptions } from "./SelectFormControl";
+import {
+  codeStructureOptions,
+  maximumFontSize,
+  minimumFontSize,
+  useSettings,
+} from "./settings";
 
 /**
  * The settings area.
@@ -44,7 +49,16 @@ const SettingsArea = () => {
     },
     [settings, setSettings]
   );
-
+  const options = useMemo(
+    () => ({
+      codeStructure: createOptions(
+        codeStructureOptions,
+        "highlight-code-structure",
+        intl
+      ),
+    }),
+    [intl]
+  );
   return (
     <VStack alignItems="flex-start" spacing={5}>
       <FormControl display="flex" alignItems="center">
@@ -75,22 +89,7 @@ const SettingsArea = () => {
       <SelectFormControl
         id="codeStructureHighlight"
         label={intl.formatMessage({ id: "highlight-code-structure" })}
-        options={[
-          {
-            value: "none",
-            label: intl.formatMessage({ id: "highlight-code-structure-none" }),
-          },
-          {
-            value: "full",
-            label: intl.formatMessage({ id: "highlight-code-structure-full" }),
-          },
-          {
-            value: "simple",
-            label: intl.formatMessage({
-              id: "highlight-code-structure-simple",
-            }),
-          },
-        ]}
+        options={options.codeStructure}
         value={settings.codeStructureHighlight}
         onChange={(codeStructureHighlight) =>
           setSettings({
@@ -100,49 +99,6 @@ const SettingsArea = () => {
         }
       />
     </VStack>
-  );
-};
-
-interface SelectFormControlProps<T> {
-  id: string;
-  options: { value: T; label: ReactNode }[];
-  label: ReactNode;
-  value: T;
-  onChange: (value: T) => void;
-}
-
-const SelectFormControl = <T extends string>({
-  id,
-  options,
-  label,
-  value,
-  onChange,
-}: SelectFormControlProps<T>) => {
-  const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) =>
-      onChange(e.currentTarget!.value as T),
-    [onChange]
-  );
-
-  return (
-    <FormControl display="flex" alignItems="center">
-      <FormLabel htmlFor={id} mb="0" fontWeight="normal" flex="1 1 auto">
-        {label}
-      </FormLabel>
-      <Select
-        id={id}
-        variant="outline"
-        onChange={handleChange}
-        width="20ch"
-        value={value}
-      >
-        {options.map(({ value, label }) => (
-          <option key={value} value={value}>
-            {label}
-          </option>
-        ))}
-      </Select>
-    </FormControl>
   );
 };
 

--- a/src/settings/SettingsArea.tsx
+++ b/src/settings/SettingsArea.tsx
@@ -20,7 +20,7 @@ import {
   codeStructureOptions,
   maximumFontSize,
   minimumFontSize,
-  signatureHelpOptions,
+  parameterHelpOptions,
   useSettings,
 } from "./settings";
 
@@ -58,9 +58,9 @@ const SettingsArea = () => {
         "highlight-code-structure",
         intl
       ),
-      parameterHints: createOptions(
-        signatureHelpOptions,
-        "parameter-hints",
+      parameterHelp: createOptions(
+        parameterHelpOptions,
+        "parameter-help",
         intl,
         {
           shortcut: (isMac ? "Cmd" : "Ctrl") + "-Shift+Space",
@@ -108,14 +108,14 @@ const SettingsArea = () => {
         }
       />
       <SelectFormControl
-        id="signatureHelp"
-        label={intl.formatMessage({ id: "parameter-hints" })}
-        options={options.parameterHints}
-        value={settings.signatureHelp}
-        onChange={(signatureHelp) =>
+        id="parameterHelp"
+        label={intl.formatMessage({ id: "parameter-help" })}
+        options={options.parameterHelp}
+        value={settings.parameterHelp}
+        onChange={(parameterHelp) =>
           setSettings({
             ...settings,
-            signatureHelp,
+            parameterHelp,
           })
         }
       />

--- a/src/settings/SettingsArea.tsx
+++ b/src/settings/SettingsArea.tsx
@@ -50,21 +50,24 @@ const SettingsArea = () => {
     },
     [settings, setSettings]
   );
-  const options = useMemo(
-    () => ({
+  const options = useMemo(() => {
+    const isMac = /Mac/.test(navigator.platform);
+    return {
       codeStructure: createOptions(
         codeStructureOptions,
         "highlight-code-structure",
         intl
       ),
-      signatureHelp: createOptions(
+      parameterHints: createOptions(
         signatureHelpOptions,
-        "function-parameter-help",
-        intl
+        "parameter-hints",
+        intl,
+        {
+          shortcut: (isMac ? "Cmd" : "Ctrl") + "-Shift+Space",
+        }
       ),
-    }),
-    [intl]
-  );
+    };
+  }, [intl]);
   return (
     <VStack alignItems="flex-start" spacing={5}>
       <FormControl display="flex" alignItems="center">
@@ -106,8 +109,8 @@ const SettingsArea = () => {
       />
       <SelectFormControl
         id="signatureHelp"
-        label={intl.formatMessage({ id: "signature-help" })}
-        options={options.signatureHelp}
+        label={intl.formatMessage({ id: "parameter-hints" })}
+        options={options.parameterHints}
         value={settings.signatureHelp}
         onChange={(signatureHelp) =>
           setSettings({

--- a/src/settings/SettingsArea.tsx
+++ b/src/settings/SettingsArea.tsx
@@ -20,6 +20,7 @@ import {
   codeStructureOptions,
   maximumFontSize,
   minimumFontSize,
+  signatureHelpOptions,
   useSettings,
 } from "./settings";
 
@@ -54,6 +55,11 @@ const SettingsArea = () => {
       codeStructure: createOptions(
         codeStructureOptions,
         "highlight-code-structure",
+        intl
+      ),
+      signatureHelp: createOptions(
+        signatureHelpOptions,
+        "function-parameter-help",
         intl
       ),
     }),
@@ -95,6 +101,18 @@ const SettingsArea = () => {
           setSettings({
             ...settings,
             codeStructureHighlight,
+          })
+        }
+      />
+      <SelectFormControl
+        id="signatureHelp"
+        label={intl.formatMessage({ id: "signature-help" })}
+        options={options.signatureHelp}
+        value={settings.signatureHelp}
+        onChange={(signatureHelp) =>
+          setSettings({
+            ...settings,
+            signatureHelp,
           })
         }
       />

--- a/src/settings/settings.test.ts
+++ b/src/settings/settings.test.ts
@@ -1,0 +1,26 @@
+import { defaultSettings, isValidSettingsObject } from "./settings";
+
+describe("isValidSettingsObject", () => {
+  it("checks parameter help", () => {
+    expect(
+      isValidSettingsObject({
+        ...defaultSettings,
+        parameterHelp: "woah",
+      })
+    ).toEqual(false);
+
+    expect(
+      isValidSettingsObject({
+        ...defaultSettings,
+        parameterHelp: "automatic",
+      })
+    ).toEqual(true);
+
+    expect(
+      isValidSettingsObject({
+        ...defaultSettings,
+        parameterHelp: "manual",
+      })
+    ).toEqual(true);
+  });
+});

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -41,8 +41,8 @@ export const minimumFontSize = 4;
 export const maximumFontSize = 154;
 export const fontSizeStep = 3;
 
-export type SignatureHelpOption = "automatic" | "manual";
-export const signatureHelpOptions: SignatureHelpOption[] = [
+export type ParameterHelpOption = "automatic" | "manual";
+export const parameterHelpOptions: ParameterHelpOption[] = [
   "automatic",
   "manual",
 ];
@@ -51,7 +51,7 @@ export const defaultSettings: Settings = {
   languageId: supportedLanguages[0].id,
   fontSize: defaultCodeFontSizePt,
   codeStructureHighlight: "full",
-  signatureHelp: "automatic",
+  parameterHelp: "automatic",
 };
 
 export const isValidSettingsObject = (value: unknown): value is Settings => {
@@ -117,7 +117,7 @@ export interface Settings {
   languageId: string;
   fontSize: number;
   codeStructureHighlight: CodeStructureOption;
-  signatureHelp: SignatureHelpOption;
+  parameterHelp: ParameterHelpOption;
 }
 
 type SettingsContextValue = [Settings, (settings: Settings) => void];

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -68,6 +68,9 @@ export const isValidSettingsObject = (value: unknown): value is Settings => {
   if (codeStructureOptions.indexOf(object.codeStructureHighlight) === -1) {
     return false;
   }
+  if (parameterHelpOptions.indexOf(object.parameterHelp) === -1) {
+    return false;
+  }
   return true;
 };
 

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -41,10 +41,14 @@ export const minimumFontSize = 4;
 export const maximumFontSize = 154;
 export const fontSizeStep = 3;
 
+export type SignatureHelpOption = "none" | "simple";
+export const signatureHelpOptions: SignatureHelpOption[] = ["none", "simple"];
+
 export const defaultSettings: Settings = {
   languageId: supportedLanguages[0].id,
   fontSize: defaultCodeFontSizePt,
   codeStructureHighlight: "full",
+  signatureHelp: "simple",
 };
 
 export const isValidSettingsObject = (value: unknown): value is Settings => {
@@ -110,6 +114,7 @@ export interface Settings {
   languageId: string;
   fontSize: number;
   codeStructureHighlight: CodeStructureOption;
+  signatureHelp: SignatureHelpOption;
 }
 
 type SettingsContextValue = [Settings, (settings: Settings) => void];

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -41,14 +41,17 @@ export const minimumFontSize = 4;
 export const maximumFontSize = 154;
 export const fontSizeStep = 3;
 
-export type SignatureHelpOption = "none" | "simple";
-export const signatureHelpOptions: SignatureHelpOption[] = ["none", "simple"];
+export type SignatureHelpOption = "automatic" | "manual";
+export const signatureHelpOptions: SignatureHelpOption[] = [
+  "automatic",
+  "manual",
+];
 
 export const defaultSettings: Settings = {
   languageId: supportedLanguages[0].id,
   fontSize: defaultCodeFontSizePt,
   codeStructureHighlight: "full",
-  signatureHelp: "simple",
+  signatureHelp: "automatic",
 };
 
 export const isValidSettingsObject = (value: unknown): value is Settings => {


### PR DESCRIPTION
Support the same keyboard interactions as VS Code:
- Mod-Shift-Space to open
- Escape to close

Add an automatic/manual option in the settings.

We had a brief discussion about naming and agreed to go with "Parameter help" for now. VS Code uses "Parameter hints". LSP uses "Signature help" but that's a more complicated notion for our users. We might revisit.