### PR TITLE
Beta prep

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ _steps:
   install_dependencies: &install_dependencies
     run: npm ci --cache .npm-cache && sudo npm config set @microbit-foundation:registry https://npm.pkg.github.com/microbit-foundation && sudo npm i -g @microbit-foundation/website-deploy-aws@0.3.0 @microbit-foundation/website-deploy-aws-config@0.4.2 @microbit-foundation/circleci-npm-package-versioner@1
   install_theme: &install_theme
-    run: npm config set @microbit-foundation:registry https://npm.pkg.github.com/microbit-foundation && npm install --no-save @microbit-foundation/python-editor-next-microbit@0.1.0-dev.120
+    run: npm config set @microbit-foundation:registry https://npm.pkg.github.com/microbit-foundation && npm install --no-save @microbit-foundation/python-editor-next-microbit@0.1.0-dev.126
   update_version: &update_version
     run: npm run ci:update-version
   build: &build

--- a/src/deployment/index.ts
+++ b/src/deployment/index.ts
@@ -17,6 +17,7 @@ export interface DeploymentConfig {
   chakraTheme: any;
 
   supportLink?: string;
+  guideLink?: string;
   termsOfUseLink?: string;
   translationLink?: string;
 

--- a/src/workbench/InfoDialog.tsx
+++ b/src/workbench/InfoDialog.tsx
@@ -96,7 +96,7 @@ const InfoDialog = ({
                     },
                   }}
                 >
-                  Documentation
+                  Guidance
                 </Button>
               </Flex>
               <Text fontSize="sm" pt={8}>

--- a/src/workbench/InfoDialog.tsx
+++ b/src/workbench/InfoDialog.tsx
@@ -61,7 +61,7 @@ const InfoDialog = ({
                     Drag and drop them into your code.
                   </ListItem>
                   <ListItem m={1}>
-                    Autocomplete and paramerer help. See the choices available
+                    Autocomplete and parameter help. See the choices available
                     to you as you type.
                   </ListItem>
                   <ListItem m={1}>

--- a/src/workbench/InfoDialog.tsx
+++ b/src/workbench/InfoDialog.tsx
@@ -4,9 +4,19 @@
  * SPDX-License-Identifier: MIT
  */
 import { Button } from "@chakra-ui/button";
-import { Link, List, ListItem, Stack, Text, VStack } from "@chakra-ui/layout";
+import {
+  Flex,
+  Link,
+  List,
+  ListItem,
+  Stack,
+  Text,
+  VStack,
+} from "@chakra-ui/layout";
 import { Modal, ModalBody, ModalContent, ModalOverlay } from "@chakra-ui/modal";
+import { RiExternalLinkLine, RiFeedbackLine } from "react-icons/ri";
 import ModalCloseButton from "../common/ModalCloseButton";
+import { useDeployment } from "../deployment";
 
 interface InfoDialogProps {
   isOpen: boolean;
@@ -20,6 +30,7 @@ const InfoDialog = ({
   onClose,
   switchToInfoDialog,
 }: InfoDialogProps) => {
+  const { supportLink } = useDeployment();
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="2xl" scrollBehavior="inside">
       <ModalOverlay>
@@ -36,58 +47,64 @@ const InfoDialog = ({
               alignItems="stretch"
             >
               <Stack spacing={3}>
-                <Text fontWeight="semibold">
-                  Welcome to the alpha release of the new micro:bit Python
-                  editor.
+                <Text as="h2" fontSize="xl" fontWeight="semibold">
+                  Python Editor V3 beta release
                 </Text>
                 <Text>
-                  This editor will change rapidly and sometimes things will
-                  break.
+                  The editor has been redesigned to improve support for teaching
+                  Python with the micro:bit. We’d love to hear your feedback.
                 </Text>
-                <Text>What's new:</Text>
+                <Text>Highlights:</Text>
                 <List listStyleType="disc" listStylePos="outside" pl={8}>
                   <ListItem m={1}>
-                    Autocomplete and signature help in the code editor.
+                    Working code examples in the <strong>Reference</strong> tab.
+                    Drag and drop them into your code.
                   </ListItem>
                   <ListItem m={1}>
-                    Drag and drop code examples from the{" "}
-                    <strong>Reference</strong> and <strong>API</strong>{" "}
-                    documentation tabs.
-                  </ListItem>
-                  <ListItem m={1}>A pre-release of Data logging.</ListItem>
-                </List>
-                <Text>Things to try:</Text>
-                <List listStyleType="disc" listStylePos="outside" pl={8}>
-                  <ListItem m={1}>
-                    Connecting your micro:bit via WebUSB. Click{" "}
-                    <strong>Connect</strong>. Check out Serial once you're
-                    connected. You can see any errors on your micro:bit in the
-                    serial area.
+                    Autocomplete and paramerer help. See the choices available
+                    to you as you type code.
                   </ListItem>
                   <ListItem m={1}>
-                    As-you-type error markers in the code editor. Catch problems
-                    before running your program.
+                    Error checking in the code editor. Catch problems before
+                    running your program.
                   </ListItem>
                 </List>
+                <Text>
+                  To get started, plug in your micro:bit and click{" "}
+                  <strong>Connect</strong>.
+                </Text>
               </Stack>
-              <VStack spacing={4} alignSelf="center" alignItems="stretch">
-                <Button size="lg" onClick={switchToInfoDialog}>
+              <Flex flexWrap="wrap" gap={3} justifyContent={["center"]}>
+                <Button
+                  size="lg"
+                  onClick={switchToInfoDialog}
+                  leftIcon={<RiFeedbackLine />}
+                >
                   Feedback
                 </Button>
                 <Button
+                  leftIcon={<RiExternalLinkLine />}
                   variant="solid"
                   as={Link}
                   size="lg"
-                  href="https://python.microbit.org"
+                  href={supportLink}
+                  target="_blank"
+                  rel="noopener"
                   sx={{
                     "&:hover": {
                       textDecoration: "none",
                     },
                   }}
                 >
-                  Stable editor
+                  Documentation
                 </Button>
-              </VStack>
+              </Flex>
+              <Text fontSize="sm" pt={8}>
+                <Link href="https://python.microbit.org/v/2" color="brand.600">
+                  Python Editor V2
+                </Link>{" "}
+                is still supported and will continue to be available.
+              </Text>
             </VStack>
           </ModalBody>
         </ModalContent>

--- a/src/workbench/InfoDialog.tsx
+++ b/src/workbench/InfoDialog.tsx
@@ -30,7 +30,7 @@ const InfoDialog = ({
   onClose,
   switchToInfoDialog,
 }: InfoDialogProps) => {
-  const { supportLink } = useDeployment();
+  const { guideLink } = useDeployment();
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="2xl" scrollBehavior="inside">
       <ModalOverlay>
@@ -87,7 +87,7 @@ const InfoDialog = ({
                   variant="solid"
                   as={Link}
                   size="lg"
-                  href={supportLink}
+                  href={guideLink}
                   target="_blank"
                   rel="noopener"
                   sx={{

--- a/src/workbench/InfoDialog.tsx
+++ b/src/workbench/InfoDialog.tsx
@@ -62,7 +62,7 @@ const InfoDialog = ({
                   </ListItem>
                   <ListItem m={1}>
                     Autocomplete and paramerer help. See the choices available
-                    to you as you type code.
+                    to you as you type.
                   </ListItem>
                   <ListItem m={1}>
                     Error checking in the code editor. Catch problems before

--- a/src/workbench/ReleaseNotice.tsx
+++ b/src/workbench/ReleaseNotice.tsx
@@ -68,7 +68,7 @@ const ReleaseNotice = ({ onDialogChange }: ReleaseNoticeProps) => {
       role="region"
     >
       <Text fontSize="sm" textAlign="center" fontWeight="semibold" p={1}>
-        Alpha release
+        Beta release
       </Text>
       <HStack>
         <Button


### PR DESCRIPTION
- Changes the alpha release notice to a beta one.
- Bumps the theme pages to a version with the simple fix that closes #669.