### PR TITLE
Enforce the minimum size of the sized component.

### DIFF
--- a/src/common/SplitView/SplitView.tsx
+++ b/src/common/SplitView/SplitView.tsx
@@ -88,12 +88,18 @@ export const SplitView = ({
           size = minimums[0];
         }
         // Check remaining space for other component vs its minimum
+        // The window can be too small for the sum of the minimums,
+        // we sacrifice the unsized component in this case.
         const maximum =
           (direction === "column" ? rect.height : rect.width) -
           separatorPixels -
           minimums[1];
         if (size > maximum) {
           size = maximum;
+        }
+        const minimum = minimums[0] - separatorPixels;
+        if (size < minimum) {
+          size = minimum;
         }
         setSizedPaneSize(size);
       }


### PR DESCRIPTION
Fixes https://github.com/microbit-foundation/python-editor-next/issues/638

@microbit-robert, please try this carefully at different window sizes.