### PR TITLE
Shrink buttons on project action bar when narrow

### DIFF
--- a/src/common/use-resize-observer.ts
+++ b/src/common/use-resize-observer.ts
@@ -10,6 +10,7 @@ export const useResizeObserverContentRect = (
     const resizeObserver = new ResizeObserver((entries) => {
       entries.forEach((entry) => {
         if (entry.contentRect) {
+          // When Safari 15.4 is widespread we can move to fooBoxSize.
           setContentRect(entry.contentRect);
         }
       });

--- a/src/project/ConnectDisconnectButton.tsx
+++ b/src/project/ConnectDisconnectButton.tsx
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: MIT
  */
 import React, { useCallback } from "react";
-import { Button, Tooltip } from "@chakra-ui/react";
+import { Button, ButtonProps, Tooltip } from "@chakra-ui/react";
 import { RiUsbLine } from "react-icons/ri";
 import { ConnectionStatus } from "../device/device";
 import { useConnectionStatus } from "../device/device-hooks";
 import { useProjectActions } from "./project-hooks";
 import { FormattedMessage, useIntl } from "react-intl";
 
-const ConnectDisconnectButton = () => {
+const ConnectDisconnectButton = (props: ButtonProps) => {
   const status = useConnectionStatus();
   const supported = status !== ConnectionStatus.NOT_SUPPORTED;
   const connected = status === ConnectionStatus.CONNECTED;
@@ -33,10 +33,10 @@ const ConnectDisconnectButton = () => {
   return (
     <Tooltip hasArrow placement="top-start" label={tooltip}>
       <Button
-        size="lg"
         variant={variant}
         leftIcon={<RiUsbLine />}
         onClick={handleToggleConnected}
+        {...props}
       >
         <FormattedMessage
           id={connected ? "disconnect-action" : "connect-action"}

--- a/src/project/DownloadFlashButton.tsx
+++ b/src/project/DownloadFlashButton.tsx
@@ -42,7 +42,7 @@ const DownloadFlashButton = ({ size }: DownloadFlashButtonProps) => {
   const variant = connected || downloadOnly ? "solid" : undefined;
 
   const actions = useProjectActions();
-  const buttonWidth = "10rem"; // 8.1 with md buttons
+  const buttonWidth = size === "md" ? "8.1md" : "10rem"; // 8.1 with md buttons
   return (
     <HStack>
       <Menu>

--- a/src/project/ProjectActionBar.tsx
+++ b/src/project/ProjectActionBar.tsx
@@ -3,29 +3,28 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { BoxProps, HStack } from "@chakra-ui/react";
+import { Box, BoxProps, HStack } from "@chakra-ui/react";
+import { useRef } from "react";
+import { useResizeObserverContentRect } from "../common/use-resize-observer";
 import ConnectDisconnectButton from "./ConnectDisconnectButton";
 import DownloadFlashButton from "./DownloadFlashButton";
 import LoadButton from "./LoadButton";
 
 const ProjectActionBar = (props: BoxProps) => {
-  const size = "lg";
+  const ref = useRef<HTMLDivElement>(null);
+  const rect = useResizeObserverContentRect(ref);
+  const size = rect && rect.width < 620 ? "md" : "lg";
+  const loadMode = rect && rect.width < 500 ? "icon" : "button";
   return (
-    <HStack
-      {...props}
-      justifyContent="space-between"
-      pt={5}
-      pb={5}
-      pl={10}
-      pr={10}
-    >
-      <HStack spacing={2.5}>
-        <DownloadFlashButton size={size} />
-        <ConnectDisconnectButton />
+    <Box {...props} ref={ref}>
+      <HStack justifyContent="space-between" py={5} px={size === "md" ? 5 : 10}>
+        <HStack spacing={2.5}>
+          <DownloadFlashButton size={size} />
+          <ConnectDisconnectButton size={size} />
+        </HStack>
+        <LoadButton mode={loadMode} size={size} />
       </HStack>
-      {/* Min-width to avoid collapsing when out of space. Needs some work on responsiveness of the action bar. */}
-      <LoadButton mode="button" size={size} minW="fit-content" />
-    </HStack>
+    </Box>
   );
 };
 


### PR DESCRIPTION
Needs to use a different width that isn't affected by padding to avoid
amusing effects in the intersection.