### PR TITLE
Remove CM workaround that's no longer needed.

### DIFF
--- a/src/editor/codemirror/language-server/diagnostics.ts
+++ b/src/editor/codemirror/language-server/diagnostics.ts
@@ -26,17 +26,6 @@ export const diagnosticsMapping = (
 
       // Skip if we can't map to the current document.
       if (from !== undefined && to !== undefined) {
-        // If `from` is the end of one line and `to` is the beginning of another
-        // then CM won't display the diagnostic inline. Shift the `to` to also
-        // be at the end of the line. Can be removed in future, see
-        // https://discuss.codemirror.net/t/diagnostics-for-the-range-from-end-of-a-line-to-the-start-of-the-next/3495
-        if (
-          from + 1 === to &&
-          document.lineAt(from).number + 1 === document.lineAt(to).number
-        ) {
-          to = from;
-        }
-
         return {
           from,
           to,


### PR DESCRIPTION
The sandbox on my CM discuss post is now fixed and we've long since
upgraded:
https://discuss.codemirror.net/t/diagnostics-for-the-range-from-end-of-a-line-to-the-start-of-the-next/3495