### PR TITLE
Move all of traceback message into link

### DIFF
--- a/src/serial/MaybeTracebackLink.tsx
+++ b/src/serial/MaybeTracebackLink.tsx
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
+import { Text } from "@chakra-ui/react";
 import { Traceback } from "../device/device-hooks";
 import { MAIN_FILE } from "../fs/fs";
 import TracebackLink from "./TracebackLink";
@@ -17,12 +18,22 @@ interface MaybeTracebackLinkProps {
 const MaybeTracebackLink = ({ traceback }: MaybeTracebackLinkProps) => {
   const { file, line } = traceback;
   if (file === MAIN_FILE && line) {
-    return <TracebackLink traceback={traceback}>line {line}</TracebackLink>;
+    return (
+      <TracebackLink traceback={traceback}>
+        <Text as={"span"} textDecoration="underline">
+          line {line}
+        </Text>{" "}
+        {traceback.error}
+      </TracebackLink>
+    );
   }
   if (file && line) {
     return (
       <TracebackLink traceback={traceback}>
-        {file} line {line}
+        <Text as={"span"} textDecoration="underline">
+          {file} line {line}
+        </Text>{" "}
+        {traceback.error}
       </TracebackLink>
     );
   }

--- a/src/serial/MaybeTracebackLink.tsx
+++ b/src/serial/MaybeTracebackLink.tsx
@@ -20,7 +20,7 @@ const MaybeTracebackLink = ({ traceback }: MaybeTracebackLinkProps) => {
   if (file === MAIN_FILE && line) {
     return (
       <TracebackLink traceback={traceback}>
-        <Text as={"span"} textDecoration="underline">
+        <Text as="span" textDecoration="underline">
           line {line}
         </Text>{" "}
         {traceback.error}
@@ -30,7 +30,7 @@ const MaybeTracebackLink = ({ traceback }: MaybeTracebackLinkProps) => {
   if (file && line) {
     return (
       <TracebackLink traceback={traceback}>
-        <Text as={"span"} textDecoration="underline">
+        <Text as="span" textDecoration="underline">
           {file} line {line}
         </Text>{" "}
         {traceback.error}

--- a/src/serial/SerialIndicators.tsx
+++ b/src/serial/SerialIndicators.tsx
@@ -48,7 +48,7 @@ const SerialIndicators = ({
           <>
             <Icon m={1} as={RiErrorWarningLine} fill="white" boxSize={5} />
             <Text color="white" whiteSpace="nowrap" data-testid="traceback">
-              <MaybeTracebackLink traceback={traceback} /> {traceback.error}
+              <MaybeTracebackLink traceback={traceback} />
             </Text>
           </>
         )}

--- a/src/serial/TracebackLink.tsx
+++ b/src/serial/TracebackLink.tsx
@@ -33,11 +33,7 @@ const TracebackLink = ({ traceback, children }: TracebackLinkProps) => {
     [setSelection, traceback]
   );
   return (
-    <Link
-      data-testid="traceback-link"
-      textDecoration="underline"
-      onClick={handleClick}
-    >
+    <Link data-testid="traceback-link" onClick={handleClick}>
       {children}
     </Link>
   );


### PR DESCRIPTION
This change makes it easier to navigate to the error in the editor.

Closes #655.