### PR TITLE
Add support for language code on URL

### DIFF
--- a/src/e2e/app.ts
+++ b/src/e2e/app.ts
@@ -43,6 +43,10 @@ interface Options {
    * URL fragment including the #.
    */
   fragment?: string;
+  /**
+   * Language parameter passed via URL.
+   */
+  language?: string;
 }
 
 /**
@@ -68,20 +72,36 @@ export class App {
   );
 
   constructor(options: Options = {}) {
+    this.url = this.optionsToURL(options);
+    this.browser = puppeteer.launch();
+    this.page = this.createPage();
+  }
+
+  setOptions(options: Options) {
+    this.url = this.optionsToURL(options);
+  }
+
+  private optionsToURL(options: Options): string {
     const flags = new Set<string>([
       "none",
       "noWelcome",
       ...(options.flags ?? []),
     ]);
-    this.url =
+    const params: Array<[string, string]> = Array.from(flags).map((f) => [
+      "flag",
+      f,
+    ]);
+    if (options.language) {
+      params.push(["l", options.language]);
+    }
+    return (
       baseUrl +
       // We don't use PUBLIC_URL here as CRA seems to set it to "" before running jest.
       (process.env.E2E_PUBLIC_URL ?? "/") +
       "?" +
-      new URLSearchParams(Array.from(flags).map((f) => ["flag", f])) +
-      (options.fragment ?? "");
-    this.browser = puppeteer.launch();
-    this.page = this.createPage();
+      new URLSearchParams(params) +
+      (options.fragment ?? "")
+    );
   }
 
   async createPage() {

--- a/src/e2e/settings.test.ts
+++ b/src/e2e/settings.test.ts
@@ -7,9 +7,26 @@ import { App } from "./app";
 
 describe("Browser - settings", () => {
   const app = new App();
-  beforeEach(app.reset.bind(app));
+  beforeEach(() => {
+    app.setOptions({});
+    return app.reset();
+  });
   afterEach(app.screenshot.bind(app));
   afterAll(app.dispose.bind(app));
+
+  it("sets language via URL", async () => {
+    app.setOptions({
+      language: "fr",
+    });
+    await app.reset();
+    // French via the URL
+    await app.findProjectName("Projet sans titre");
+
+    await app.switchLanguage("en");
+    await app.reset();
+    // French URL ignored as we've made an explicit language choice.
+    await app.findProjectName("Untitled project");
+  });
 
   it("switches language", async () => {
     // NOTE: the app methods generally won't still work after changing language.

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -47,8 +47,15 @@ export const parameterHelpOptions: ParameterHelpOption[] = [
   "manual",
 ];
 
+export const getLanguageFromQuery = (): string => {
+  const searchParams = new URLSearchParams(window.location.search);
+  const l = searchParams.get("l");
+  const supportedLanguage = supportedLanguages.find((x) => x.id === l);
+  return supportedLanguage?.id || supportedLanguages[0].id;
+};
+
 export const defaultSettings: Settings = {
-  languageId: supportedLanguages[0].id,
+  languageId: getLanguageFromQuery(),
   fontSize: defaultCodeFontSizePt,
   codeStructureHighlight: "full",
   parameterHelp: "automatic",


### PR DESCRIPTION
Intentionally supports the same l=${code} syntax as the V2 editor to help keep links elsewhere working.

Closes #536