### PR TITLE
Use safer method to prevent tooltips moving

### DIFF
--- a/src/editor/codemirror/lint/lint.ts
+++ b/src/editor/codemirror/lint/lint.ts
@@ -704,8 +704,11 @@ function trackHoverOn(view: EditorView, marker: HTMLElement) {
 }
 
 function gutterMarkerMouseOver(view: EditorView, marker: HTMLElement, diagnostics: readonly Diagnostic[]) {
-  let line = view.elementAtHeight(marker.getBoundingClientRect().top + 5 - view.documentTop)
   function hovered() {
+    if (marker.getBoundingClientRect().top === 0) {
+      return
+    }
+    let line = view.elementAtHeight(marker.getBoundingClientRect().top + 5 - view.documentTop)
     const linePos = view.coordsAtPos(line.from)
     if (linePos) {
       view.dispatch({effects: setLintGutterTooltip.of({
@@ -719,6 +722,7 @@ function gutterMarkerMouseOver(view: EditorView, marker: HTMLElement, diagnostic
         }
       })})
     }
+   
     marker.onmouseout = marker.onmousemove = null
     trackHoverOn(view, marker)
   }


### PR DESCRIPTION
In the previous version, I noticed the following:

https://user-images.githubusercontent.com/95928279/163410364-57820539-891c-43cd-af9b-4608dc9baa63.mp4

Hover the gutter error for the tooltip, then make changes whilst the tooltip is visible that will push the tooltip to a different line. This crashes the editor.

The proposed changed does not result in these errors, but maintains the behaviour of preventing the tooltips from moving when typing.