### PR TITLE
Bump notice version for alpha -> beta.

### DIFF
--- a/src/workbench/ReleaseNotice.tsx
+++ b/src/workbench/ReleaseNotice.tsx
@@ -13,7 +13,7 @@ import { flags } from "../flags";
 export type ReleaseNoticeState = "info" | "feedback" | "closed";
 
 // Bump this to show the notice again.
-const currentVersion = 1;
+const currentVersion = 2;
 
 interface ReleaseNoticeStorage {
   version: number;


### PR DESCRIPTION
So folks who previously saw the alpha notice see the beta one. At least initially the domain will be the same.