### PR TITLE
Fix boot event.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,7 @@ fs.initializeInBackground();
 
 const App = () => {
   useEffect(() => {
-    logging.event({ action: "boot" });
+    logging.event({ type: "boot" });
     device.initialize();
     return () => {
       device.dispose();

--- a/src/deployment/index.ts
+++ b/src/deployment/index.ts
@@ -8,7 +8,7 @@ import { Logging } from "../logging/logging";
 
 // This is configured via a webpack alias, defaulting to ./default
 import { default as d } from "theme-package";
-export const deployment = d;
+export const deployment: DeploymentConfig = d;
 
 export interface DeploymentConfig {
   squareLogo?: ReactNode;


### PR DESCRIPTION
Should be type not action, not spotted as in this one scenario (not
using the hook) deployment was typed `any`.