### PR TITLE
Fix for image responsiveness

### DIFF
--- a/src/common/documentation-styles.ts
+++ b/src/common/documentation-styles.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 export const docStyles = {
-  "p,img": {
+  "p,h3": {
     maxWidth: "600px",
   },
 };

--- a/src/documentation/ideas/IdeasDocumentation.tsx
+++ b/src/documentation/ideas/IdeasDocumentation.tsx
@@ -101,7 +101,7 @@ const ActiveLevel = ({
                   .fit("max")
                   .url()}
                 alt=""
-                width="100%"
+                width={600}
                 sx={{
                   aspectRatio: getAspectRatio(activeIdea.image.asset._ref),
                 }}


### PR DESCRIPTION
This allows toolkit images to shrink below their set widths preventing the reference tab layout issue referenced below.

Closes #707 