### PR TITLE
Make code examples focusable

### DIFF
--- a/src/documentation/api/ApiNode.test.tsx
+++ b/src/documentation/api/ApiNode.test.tsx
@@ -6,6 +6,7 @@
 import { render } from "@testing-library/react";
 import { ApiDocsEntry } from "../../language-server/apidocs";
 import NullLoggingProvider from "../../logging/NullLoggingProvider";
+import { ActiveEditorProvider } from "../../editor/active-editor-hooks";
 import FixedTranslationProvider from "../../messages/FixedTranslationProvider";
 import ScrollablePanel from "../../common/ScrollablePanel";
 import ApiNode, { getDragContext, classToInstanceMap } from "./ApiNode";
@@ -43,9 +44,11 @@ describe("ApiNode", () => {
     render(
       <FixedTranslationProvider>
         <NullLoggingProvider>
-          <ScrollablePanel>
-            <ApiNode docs={node} />
-          </ScrollablePanel>
+          <ActiveEditorProvider>
+            <ScrollablePanel>
+              <ApiNode docs={node} />
+            </ScrollablePanel>
+          </ActiveEditorProvider>
         </NullLoggingProvider>
       </FixedTranslationProvider>
     );

--- a/src/documentation/api/ApiNode.tsx
+++ b/src/documentation/api/ApiNode.tsx
@@ -381,10 +381,10 @@ const DraggableSignature = ({
         e.preventDefault();
         handleInsertCode();
       }
-      if (e.key === "c" && (isMac ? e.metaKey : e.ctrlKey)) {
+      if ((e.key === "c" || e.key === "C") && (isMac ? e.metaKey : e.ctrlKey)) {
         e.preventDefault();
         await navigator.clipboard.writeText(
-          `${formatName(kind, fullName, name)}${signature}`
+          `${formatName(kind, fullName, name)}${signature ? signature : ""}`
         );
       }
     },

--- a/src/documentation/api/ApiNode.tsx
+++ b/src/documentation/api/ApiNode.tsx
@@ -372,7 +372,7 @@ const DraggableSignature = ({
   const actions = useActiveEditorActions();
   const handleInsertCode = useCallback(() => {
     const { code, id } = getDragContext(fullName, kind);
-    actions?.insertCode(code, id);
+    actions?.insertCode(code, kind === "function" ? "call" : "example", id);
   }, [actions, fullName, kind]);
   const isMac = /Mac/.test(navigator.platform);
   const handleKeyDown = useCallback(

--- a/src/documentation/api/ApiNode.tsx
+++ b/src/documentation/api/ApiNode.tsx
@@ -8,6 +8,7 @@ import { Collapse, useDisclosure } from "@chakra-ui/react";
 import { default as React, ReactNode, useCallback, useMemo } from "react";
 import { FormattedMessage, IntlShape, useIntl } from "react-intl";
 import { pythonSnippetMediaType } from "../../common/mediaTypes";
+import { useActiveEditorActions } from "../../editor/active-editor-hooks";
 import {
   debug as dndDebug,
   DragContext,
@@ -367,6 +368,28 @@ const DraggableSignature = ({
   }, []);
 
   const highlight = useDisclosure();
+
+  const actions = useActiveEditorActions();
+  const handleInsertCode = useCallback(() => {
+    const { code, id } = getDragContext(fullName, kind);
+    actions?.insertCode(code, id);
+  }, [actions, fullName, kind]);
+  const isMac = /Mac/.test(navigator.platform);
+  const handleKeyDown = useCallback(
+    async (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        handleInsertCode();
+      }
+      if (e.key === "c" && (isMac ? e.metaKey : e.ctrlKey)) {
+        e.preventDefault();
+        await navigator.clipboard.writeText(
+          `${formatName(kind, fullName, name)}${signature}`
+        );
+      }
+    },
+    [fullName, handleInsertCode, isMac, kind, name, signature]
+  );
   return (
     <HStack
       draggable
@@ -380,6 +403,14 @@ const DraggableSignature = ({
       borderRadius="lg"
       onMouseEnter={highlight.onOpen}
       onMouseLeave={highlight.onClose}
+      tabIndex={0}
+      _focus={{
+        boxShadow: "var(--chakra-shadows-outline);",
+      }}
+      _focusVisible={{
+        outline: "none",
+      }}
+      onKeyDown={handleKeyDown}
       {...props}
       cursor="grab"
     >

--- a/src/documentation/common/CodeEmbed.tsx
+++ b/src/documentation/common/CodeEmbed.tsx
@@ -71,7 +71,7 @@ const CodeEmbed = ({ code: codeWithImports, parentSlug }: CodeEmbedProps) => {
 
   const actions = useActiveEditorActions();
   const handleInsertCode = useCallback(
-    () => actions?.insertCode(codeWithImports, parentSlug),
+    () => actions?.insertCode(codeWithImports, "example", parentSlug),
     [actions, codeWithImports, parentSlug]
   );
 

--- a/src/documentation/common/CodeEmbed.tsx
+++ b/src/documentation/common/CodeEmbed.tsx
@@ -95,7 +95,20 @@ const CodeEmbed = ({ code: codeWithImports, parentSlug }: CodeEmbedProps) => {
   const textHeight = lineCount * 1.375 + "em";
   const codeHeight = `calc(${textHeight} + var(--chakra-space-2) + var(--chakra-space-2))`;
   const codePopUpHeight = `calc(${codeHeight} + 2px)`; // Account for border.
-
+  const isMac = /Mac/.test(navigator.platform);
+  const handleKeyDown = useCallback(
+    async (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        handleInsertCode();
+      }
+      if (e.key === "c" && (isMac ? e.metaKey : e.ctrlKey)) {
+        e.preventDefault();
+        await navigator.clipboard.writeText(code);
+      }
+    },
+    [code, handleInsertCode, isMac]
+  );
   return (
     <Box>
       <Box height={codeHeight} fontSize="md">
@@ -109,6 +122,15 @@ const CodeEmbed = ({ code: codeWithImports, parentSlug }: CodeEmbedProps) => {
           ref={codeRef}
           background={state === "default" ? "white" : "blimpTeal.50"}
           highlightDragHandle={state === "raised"}
+          tabIndex={0}
+          _focus={{
+            boxShadow: "var(--chakra-shadows-outline);",
+          }}
+          _focusVisible={{
+            outline: "none",
+          }}
+          onKeyDown={handleKeyDown}
+          zIndex={1}
         />
         {state === "raised" && (
           <CodePopUp

--- a/src/documentation/common/CodeEmbed.tsx
+++ b/src/documentation/common/CodeEmbed.tsx
@@ -102,7 +102,7 @@ const CodeEmbed = ({ code: codeWithImports, parentSlug }: CodeEmbedProps) => {
         e.preventDefault();
         handleInsertCode();
       }
-      if (e.key === "c" && (isMac ? e.metaKey : e.ctrlKey)) {
+      if ((e.key === "c" || e.key === "C") && (isMac ? e.metaKey : e.ctrlKey)) {
         e.preventDefault();
         await navigator.clipboard.writeText(code);
       }

--- a/src/editor/active-editor-hooks.tsx
+++ b/src/editor/active-editor-hooks.tsx
@@ -5,6 +5,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
+import { redo, undo } from "@codemirror/history";
 import { EditorView } from "@codemirror/view";
 import React, {
   Dispatch,
@@ -13,9 +14,9 @@ import React, {
   useContext,
   useState,
 } from "react";
-import { undo, redo } from "@codemirror/history";
-import { calculateChanges } from "./codemirror/edits";
 import { Logging } from "../logging/logging";
+import { CodeInsertType } from "./codemirror/dnd";
+import { calculateChanges } from "./codemirror/edits";
 
 /**
  * Actions that operate on a CM editor.
@@ -28,12 +29,12 @@ export class EditorActions {
    *
    * @param code The code with any required imports.
    */
-  insertCode = (code: string, id?: string): void => {
+  insertCode = (code: string, type: CodeInsertType, id?: string): void => {
     this.logging.event({
       type: "code-insert",
       message: id,
     });
-    this.view.dispatch(calculateChanges(this.view.state, code, "example"));
+    this.view.dispatch(calculateChanges(this.view.state, code, type));
     this.view.focus();
   };
   undo = (): void => {


### PR DESCRIPTION
Make code examples focusable. After the element is focused: 
- Use `ctrl + c` to copy text inside the code example. This copies the text shown (does not include imports, includes signatures in the API toolkit).
- Use `Enter` to insert the code into the editor. This works in the same way as the insert code button does for the Reference toolkit.

Closes #700.