### PR TITLE
Add visually hidden text to code examples.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -131,6 +131,10 @@
     "defaultMessage": "Code editor",
     "description": "Aria label for the code editor"
   },
+  "code-example": {
+    "defaultMessage": "Code example:",
+    "description": "Visually hidden text to announce code examples in the toolkit documentation"
+  },
   "confirm-action": {
     "defaultMessage": "Confirm",
     "description": "Confirm action label"

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -131,6 +131,10 @@
     "defaultMessage": "Éditeur de code",
     "description": "Aria label for the code editor"
   },
+  "code-example": {
+    "defaultMessage": "Code example:",
+    "description": "Visually hidden text to announce code examples in the toolkit documentation"
+  },
   "confirm-action": {
     "defaultMessage": "Confirmer",
     "description": "Confirm action label"

--- a/lang/lol.json
+++ b/lang/lol.json
@@ -131,6 +131,10 @@
     "defaultMessage": "Cоде едітор",
     "description": "Aria label for the code editor"
   },
+  "code-example": {
+    "defaultMessage": "Code example:",
+    "description": "Visually hidden text to announce code examples in the toolkit documentation"
+  },
   "confirm-action": {
     "defaultMessage": "Cонфірм",
     "description": "Confirm action label"

--- a/src/documentation/api/ApiNode.tsx
+++ b/src/documentation/api/ApiNode.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { Box, BoxProps, HStack, Stack, Text, VStack } from "@chakra-ui/layout";
-import { Collapse, useDisclosure } from "@chakra-ui/react";
+import { Collapse, useDisclosure, VisuallyHidden } from "@chakra-ui/react";
 import { default as React, ReactNode, useCallback, useMemo } from "react";
 import { FormattedMessage, IntlShape, useIntl } from "react-intl";
 import { pythonSnippetMediaType } from "../../common/mediaTypes";
@@ -414,6 +414,9 @@ const DraggableSignature = ({
       {...props}
       cursor="grab"
     >
+      <VisuallyHidden>
+        <FormattedMessage id="code-example" />
+      </VisuallyHidden>
       <DragHandle
         highlight={highlight.isOpen}
         borderTopLeftRadius="lg"

--- a/src/documentation/common/CodeEmbed.tsx
+++ b/src/documentation/common/CodeEmbed.tsx
@@ -6,6 +6,7 @@
 import { Button } from "@chakra-ui/button";
 import { Box, BoxProps, HStack } from "@chakra-ui/layout";
 import { Portal } from "@chakra-ui/portal";
+import { VisuallyHidden } from "@chakra-ui/react";
 import { forwardRef } from "@chakra-ui/system";
 import { Ref, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { RiDownloadFill } from "react-icons/ri";
@@ -289,6 +290,9 @@ const Code = forwardRef<CodeProps, "pre">(
         cursor="grab"
         {...props}
       >
+        <VisuallyHidden>
+          <FormattedMessage id="code-example" />
+        </VisuallyHidden>
         <DragHandle
           borderTopLeftRadius="lg"
           p={1}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -297,6 +297,12 @@
       "value": "Code editor"
     }
   ],
+  "code-example": [
+    {
+      "type": 0,
+      "value": "Code example:"
+    }
+  ],
   "confirm-action": [
     {
       "type": 0,

--- a/src/messages/fr.json
+++ b/src/messages/fr.json
@@ -297,6 +297,12 @@
       "value": "Éditeur de code"
     }
   ],
+  "code-example": [
+    {
+      "type": 0,
+      "value": "Code example:"
+    }
+  ],
   "confirm-action": [
     {
       "type": 0,

--- a/src/messages/lol.json
+++ b/src/messages/lol.json
@@ -297,6 +297,12 @@
       "value": "Cоде едітор"
     }
   ],
+  "code-example": [
+    {
+      "type": 0,
+      "value": "Code example:"
+    }
+  ],
   "confirm-action": [
     {
       "type": 0,


### PR DESCRIPTION
When using a screen reader, code examples are now announced as such to help distinguish them from the rest of the toolkit text.

Adds a UI string.