### PR TITLE
Fix for RangeError

### DIFF
--- a/src/editor/codemirror/structure-highlighting/doc-util.ts
+++ b/src/editor/codemirror/structure-highlighting/doc-util.ts
@@ -28,7 +28,7 @@ import { Line } from "@codemirror/text";
  */
 export const skipBodyTrailers = (
   state: EditorState,
-  hints: DecorationSet,
+  hints: DecorationSet | undefined,
   position: number,
   min: number = 0
 ): number | undefined => {
@@ -45,18 +45,21 @@ export const skipBodyTrailers = (
   return undefined;
 };
 
-const isSkipLine = (line: Line, hints: DecorationSet) =>
+const isSkipLine = (line: Line, hints: DecorationSet | undefined) =>
   line.length === 0 ||
   /^\s+$/.test(line.text) ||
   /^\s*#/.test(line.text) ||
   overlapsUnnecessaryCode(hints, line.from, line.to);
 
 export const overlapsUnnecessaryCode = (
-  d: DecorationSet,
+  d: DecorationSet | undefined,
   from: number,
   to: number
 ) => {
   let overlaps: boolean = false;
+  if (!d) {
+    return overlaps;
+  }
   d.between(from, to, (_from, _to, value) => {
     if (value.spec.diagnostic.tags?.includes("unnecessary")) {
       overlaps = true;

--- a/src/editor/codemirror/structure-highlighting/view.ts
+++ b/src/editor/codemirror/structure-highlighting/view.ts
@@ -68,7 +68,7 @@ export const codeStructureView = (option: "full" | "simple") =>
           depth: number,
           body: boolean
         ) => {
-          const diagnostics = state.field(lintState).diagnostics;
+          const diagnostics = state.field(lintState, false)?.diagnostics;
           const leftEdge =
             view.contentDOM.getBoundingClientRect().left -
             view.scrollDOM.getBoundingClientRect().left;


### PR DESCRIPTION
Fix for `RangeError` observed in dev tools when running the project locally. Occurs when there is no `lintState` field in the CodeMirror editor state.