### PR TITLE
Update default code.

### DIFF
--- a/src/fs/fs.test.ts
+++ b/src/fs/fs.test.ts
@@ -236,7 +236,7 @@ describe("Filesystem", () => {
 
     await ufs.write(
       MAIN_FILE,
-      "from __future__ import hope\n" + defaultMainFileContent,
+      "from __future__ import hope\ndisplay.scroll('Hello, World')\n",
       VersionAction.MAINTAIN
     );
     const data = new Uint8Array(512);
@@ -244,8 +244,8 @@ describe("Filesystem", () => {
     await ufs.write("other.dat", data, VersionAction.INCREMENT);
     expect(await ufs.statistics()).toEqual({
       files: 2,
-      lines: 10,
-      storageUsed: 896,
+      lines: 3,
+      storageUsed: 768,
     });
   });
 });

--- a/src/fs/initial-project.ts
+++ b/src/fs/initial-project.ts
@@ -32,10 +32,11 @@ export const projectFilesToBase64 = (
   return files;
 };
 
-export const defaultMainFileContent = `# Add your Python code here. E.g.
+export const defaultMainFileContent = `# Imports go at the top
 from microbit import *
 
 
+# Code in a 'while True:' loop repeats forever
 while True:
     display.scroll('micro:bit')
     display.show(Image.HEART)


### PR DESCRIPTION
This version is intended to provide reassurance that imports belong at
the top, addressing user testing scenarios where users have tried to
keep an inserted import and function call together.

I've changed the test not to reuse the default content.

Last time I changed the main code the e2e tests failed, but this comment
only change doesn't produce that effect.