### PR TITLE
[DEMO DO NOT MERGE] Remove insert code in favour of copy/paste

### DIFF
--- a/src/common/zIndex.ts
+++ b/src/common/zIndex.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: MIT
  */
-export const zIndexCode = 1;
 export const zIndexCodePopUp = 2;
 export const zIndexBreadcrumbContainer = 2;
 export const zIndexSidebarHeader = 3;

--- a/src/documentation/common/DocumentationContent.test.tsx
+++ b/src/documentation/common/DocumentationContent.test.tsx
@@ -1,4 +1,6 @@
 /**
+ * @jest-environment ./src/testing/custom-browser-env
+ *
  * (c) 2021, Micro:bit Educational Foundation and contributors
  *
  * SPDX-License-Identifier: MIT

--- a/src/documentation/common/DragHandle.tsx
+++ b/src/documentation/common/DragHandle.tsx
@@ -15,12 +15,12 @@ const DragHandle = ({ highlight, ...props }: DragHandleProps) => {
     <HStack
       cursor="grab"
       {...props}
-      bgColor={highlight ? "blimpTeal.300" : "blimpTeal.50"}
+      bgColor={highlight ? "blimpTeal.300" : "blimpTeal.100"}
       transition="background .2s"
     >
       <DragHandleIcon
         boxSize={3}
-        color={highlight ? "blimpTeal.600" : "blimpTeal.300"}
+        color="blimpTeal.600"
         transition="color .2s"
       />
     </HStack>

--- a/src/e2e/app.ts
+++ b/src/e2e/app.ts
@@ -557,6 +557,27 @@ export class App {
     });
   }
 
+  async copyToolkitCode(name: string): Promise<void> {
+    const document = await this.document();
+    const heading = await document.findByText(name, {
+      selector: "h3",
+    });
+    const handle = heading.asElement();
+    await handle!.evaluate((element) => {
+      const item = element.closest("li");
+      (item!.querySelector(".cm-content") as HTMLButtonElement)!.click();
+    });
+  }
+
+  async pasteToolkitCode(): Promise<void> {
+    await this.focusEditorContent();
+    const keyboard = (await this.page).keyboard;
+    const meta = process.platform === "darwin" ? "Meta" : "Control";
+    await keyboard.down(meta);
+    await keyboard.press("v");
+    await keyboard.up(meta);
+  }
+
   async selectToolkitDropDownOption(
     label: string,
     option: string
@@ -856,7 +877,7 @@ export class App {
 
   private async focusEditorContent(): Promise<ElementHandle> {
     const document = await this.document();
-    const content = await document.$(".cm-content");
+    const content = await document.$("[data-testid='editor'] .cm-content");
     if (!content) {
       throw new Error("Missing editor area");
     }

--- a/src/e2e/documentation.test.ts
+++ b/src/e2e/documentation.test.ts
@@ -19,29 +19,27 @@ describe("Browser - toolkit tabs", () => {
     );
   });
 
-  it("Insert code", async () => {
+  it("Copy code and paste in editor", async () => {
     await app.switchTab("Reference");
     await app.selectDocumentationSection("Display");
     await app.selectAllInEditor();
     await app.typeInEditor("# Initial document");
-
-    await app.insertToolkitCode("Images: built-in");
-
+    await app.copyToolkitCode("Images: built-in");
+    await app.pasteToolkitCode();
     await app.findVisibleEditorContents("display.show(Image.HEART)");
   });
 
-  it("Insert code after dropdown choice", async () => {
+  it("Copy code after dropdown choice and paste in editor", async () => {
     await app.switchTab("Reference");
     await app.selectDocumentationSection("Display");
     await app.selectAllInEditor();
     await app.typeInEditor("# Initial document");
-
     await app.selectToolkitDropDownOption(
       "Select image:",
       "9" // "Image.SILLY"
     );
-    await app.insertToolkitCode("Images: built-in");
-
+    await app.copyToolkitCode("Images: built-in");
+    await app.pasteToolkitCode();
     await app.findVisibleEditorContents("display.show(Image.SILLY)");
   });
 

--- a/src/editor/active-editor-hooks.tsx
+++ b/src/editor/active-editor-hooks.tsx
@@ -15,28 +15,12 @@ import React, {
   useState,
 } from "react";
 import { Logging } from "../logging/logging";
-import { CodeInsertType } from "./codemirror/dnd";
-import { calculateChanges } from "./codemirror/edits";
 
 /**
  * Actions that operate on a CM editor.
  */
 export class EditorActions {
   constructor(private view: EditorView, private logging: Logging) {}
-
-  /**
-   * A smart, import-aware code insert.
-   *
-   * @param code The code with any required imports.
-   */
-  insertCode = (code: string, type: CodeInsertType, id?: string): void => {
-    this.logging.event({
-      type: "code-insert",
-      message: id,
-    });
-    this.view.dispatch(calculateChanges(this.view.state, code, type));
-    this.view.focus();
-  };
   undo = (): void => {
     this.logging.event({
       type: "undo",

--- a/src/editor/codemirror/config.ts
+++ b/src/editor/codemirror/config.ts
@@ -11,7 +11,6 @@ import { defaultHighlightStyle } from "@codemirror/highlight";
 import { history, historyKeymap } from "@codemirror/history";
 import { python } from "@codemirror/lang-python";
 import { indentOnInput, indentUnit } from "@codemirror/language";
-import { lintKeymap } from "./lint/lint";
 import { Compartment, EditorState, Extension, Prec } from "@codemirror/state";
 import {
   drawSelection,
@@ -20,9 +19,11 @@ import {
   KeyBinding,
   keymap,
 } from "@codemirror/view";
+import { copyPasteSupport } from "./copypaste";
 import { dndSupport } from "./dnd";
 import { dropCursor } from "./dropcursor";
 import highlightStyle from "./highlightStyle";
+import { lintKeymap } from "./lint/lint";
 
 const customTabBinding: KeyBinding = {
   key: "Tab",
@@ -67,4 +68,5 @@ export const editorConfig: Extension = [
   indentUnit.of(" ".repeat(indentSize)),
   python(),
   dndSupport(),
+  copyPasteSupport(),
 ];

--- a/src/editor/codemirror/copypaste.ts
+++ b/src/editor/codemirror/copypaste.ts
@@ -46,20 +46,9 @@ const copyPasteHandlers = () => {
           value: lineCount,
         });
 
-        let lineNumber = 0;
-        const lineElement = event
-          .composedPath()
-          .find((e) => (e as HTMLElement).classList.contains("cm-line"));
-        const lineElements = document.querySelectorAll(
-          '[data-testid="editor"] .cm-line'
-        );
-        lineElements.forEach((e, i) => {
-          if (e === lineElement) {
-            // + 1 for current line (or above existing text).
-            // + 2 for for line below.
-            lineNumber = i + 1;
-          }
-        });
+        const lineNumber = view.state.doc.lineAt(
+          view.state.selection.ranges[0].from
+        ).number;
 
         view.dispatch(
           calculateChanges(

--- a/src/editor/codemirror/copypaste.ts
+++ b/src/editor/codemirror/copypaste.ts
@@ -1,0 +1,80 @@
+import { Extension } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { lineNumFromUint8Array } from "../../common/text-util";
+import { deployment } from "../../deployment";
+import { CodeInsertType } from "./dnd";
+import { calculateChanges } from "./edits";
+
+export interface CopyContext {
+  code: string;
+  type: CodeInsertType;
+  id?: string;
+}
+
+let copyContext: CopyContext | undefined;
+
+/**
+ * Set the copied code.
+ *
+ * There's no way to pass the code type on the ClipboardItem when
+ * manually creating writing data to the clipboard.
+ *
+ * Set it in handleCopyCode and clear it on paste below.
+ */
+export const setCopyContext = (context: CopyContext | undefined) => {
+  copyContext = context;
+};
+
+const copyPasteHandlers = () => {
+  const textEncoder = new TextEncoder();
+  return [
+    EditorView.domEventHandlers({
+      paste(event, view) {
+        if (!view.state.facet(EditorView.editable) || !copyContext) {
+          return;
+        }
+        event.preventDefault();
+
+        // Should we use lineCount here, or follow the dnd logging?
+        // If we use lineCount, should we ignore imports and empty lines?
+        const lineCount = lineNumFromUint8Array(
+          // Ignore leading/trailing lines.
+          textEncoder.encode(copyContext.code.trim())
+        );
+        deployment.logging.event({
+          type: "paste",
+          value: lineCount,
+        });
+
+        let lineNumber = 0;
+        const lineElement = event
+          .composedPath()
+          .find((e) => (e as HTMLElement).classList.contains("cm-line"));
+        const lineElements = document.querySelectorAll(
+          '[data-testid="editor"] .cm-line'
+        );
+        lineElements.forEach((e, i) => {
+          if (e === lineElement) {
+            // + 1 for current line (or above existing text).
+            // + 2 for for line below.
+            lineNumber = i + 1;
+          }
+        });
+
+        view.dispatch(
+          calculateChanges(
+            view.state,
+            copyContext.code,
+            copyContext.type,
+            lineNumber
+          )
+        );
+        view.focus();
+        // How long should we keep this on the 'clipboard'?
+        copyContext = undefined;
+      },
+    }),
+  ];
+};
+
+export const copyPasteSupport = (): Extension => [copyPasteHandlers()];


### PR DESCRIPTION
Remove insert code button, and instead allow users to either click on a code snippet, or focus a code element with tab and press `enter`/`ctrl/cmd + c` to copy the code. When pasted into the editor, the body of the code is pasted on the selected line, with imports maintained at the top of the editor.