### PR TITLE
Fix module name validation.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -27,10 +27,6 @@
     "defaultMessage": "Added file {changeName}",
     "description": "Change made to file"
   },
-  "already-exists": {
-    "defaultMessage": "This file already exists",
-    "description": "File already exists notification text"
-  },
   "api-description": {
     "defaultMessage": "API documentation for micro:bit MicroPython",
     "description": "Description at the top of the API tab"
@@ -255,6 +251,38 @@
     "defaultMessage": "{name} file actions",
     "description": "Header of file actions for file"
   },
+  "file-already-exists": {
+    "defaultMessage": "This file already exists",
+    "description": "File already exists notification text"
+  },
+  "file-name-invalid-character": {
+    "defaultMessage": "The name contains an invalid character: {invalid}",
+    "description": "Warning text for new Python file name with an invalid character"
+  },
+  "file-name-length": {
+    "defaultMessage": "The name is too long",
+    "description": "Warning text for overly long file names (file system limitation)"
+  },
+  "file-name-lowercase-only": {
+    "defaultMessage": "The name should be all lowercase",
+    "description": "Warning text for new Python file with uppercase"
+  },
+  "file-name-not-blank": {
+    "defaultMessage": "The project name cannot be blank",
+    "description": "Validation message for project name"
+  },
+  "file-name-not-empty": {
+    "defaultMessage": "The name cannot be empty",
+    "description": "Warning text for new Python file with empty name"
+  },
+  "file-name-start-number": {
+    "defaultMessage": "The name cannot start with a number",
+    "description": "Warning text for new Python file names starting with a number"
+  },
+  "file-name-whitespace": {
+    "defaultMessage": "The name cannot contain spaces",
+    "description": "Warning text for new Python file name with whitespace"
+  },
   "firmware-update-link": {
     "defaultMessage": "You must <link>update your firmware</link> before you can connect to this micro:bit.",
     "description": "Text in the firmware update dialog"
@@ -363,10 +391,6 @@
     "defaultMessage": "Loading…",
     "description": "Shown on loading indicators"
   },
-  "lowercase-no-space": {
-    "defaultMessage": "Python files should have lowercase names with no spaces",
-    "description": "Warning text for uppercase Pyton file name or space"
-  },
   "microbit-hearts-alt": {
     "defaultMessage": "micro:bit board with the 5 by 5 LED grid showing a heart",
     "description": "Alt text for micro:bit image in About dialog"
@@ -390,14 +414,6 @@
   "more-download-options": {
     "defaultMessage": "More download options",
     "description": "Aria label for the additional actions menu to the right of the Download/Flash button"
-  },
-  "name-not-blank": {
-    "defaultMessage": "The project name cannot be blank",
-    "description": "Validation message for project name"
-  },
-  "name-not-empty": {
-    "defaultMessage": "The name cannot be empty",
-    "description": "Warning text for new Pyton file with empty name"
   },
   "name-project": {
     "defaultMessage": "Name your project",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -27,10 +27,6 @@
     "defaultMessage": "Fichier ajouté {changeName}",
     "description": "Change made to file"
   },
-  "already-exists": {
-    "defaultMessage": "Ce fichier existe déjà",
-    "description": "File already exists notification text"
-  },
   "api-description": {
     "defaultMessage": "Documentation d’API pour la carte micro:bit MicroPython",
     "description": "Description at the top of the API tab"
@@ -255,6 +251,38 @@
     "defaultMessage": "Actions sur le fichier {name}",
     "description": "Header of file actions for file"
   },
+  "file-already-exists": {
+    "defaultMessage": "This file already exists",
+    "description": "File already exists notification text"
+  },
+  "file-name-invalid-character": {
+    "defaultMessage": "The name contains an invalid character: {invalid}",
+    "description": "Warning text for new Python file name with an invalid character"
+  },
+  "file-name-length": {
+    "defaultMessage": "The name is too long",
+    "description": "Warning text for overly long file names (file system limitation)"
+  },
+  "file-name-lowercase-only": {
+    "defaultMessage": "The name should be all lowercase",
+    "description": "Warning text for new Python file with uppercase"
+  },
+  "file-name-not-blank": {
+    "defaultMessage": "The project name cannot be blank",
+    "description": "Validation message for project name"
+  },
+  "file-name-not-empty": {
+    "defaultMessage": "The name cannot be empty",
+    "description": "Warning text for new Python file with empty name"
+  },
+  "file-name-start-number": {
+    "defaultMessage": "The name cannot start with a number",
+    "description": "Warning text for new Python file names starting with a number"
+  },
+  "file-name-whitespace": {
+    "defaultMessage": "The name cannot contain spaces",
+    "description": "Warning text for new Python file name with whitespace"
+  },
   "firmware-update-link": {
     "defaultMessage": "You must <link>update your firmware</link> before you can connect to this micro:bit.",
     "description": "Text in the firmware update dialog"
@@ -362,10 +390,6 @@
     "defaultMessage": "Chargement…",
     "description": "Shown on loading indicators"
   },
-  "lowercase-no-space": {
-    "defaultMessage": "Les fichiers Python doivent avoir des noms en minuscules et sans espaces",
-    "description": "Warning text for uppercase Pyton file name or space"
-  },
   "microbit-hearts-alt": {
     "defaultMessage": "Tableau du micro:bit avec la grille LED 5 par 5 montrant un cœur",
     "description": "Alt text for micro:bit image in About dialog"
@@ -389,14 +413,6 @@
   "more-download-options": {
     "defaultMessage": "Plus d’options de téléchargement",
     "description": "Aria label for the additional actions menu to the right of the Download/Flash button"
-  },
-  "name-not-blank": {
-    "defaultMessage": "Le nom du projet ne doit pas être laissé vide",
-    "description": "Validation message for project name"
-  },
-  "name-not-empty": {
-    "defaultMessage": "Le nom ne doit pas être vide",
-    "description": "Warning text for new Pyton file with empty name"
   },
   "name-project": {
     "defaultMessage": "Donnez un nom à votre projet",

--- a/lang/lol.json
+++ b/lang/lol.json
@@ -27,10 +27,6 @@
     "defaultMessage": "Аддед філе {changeName}",
     "description": "Change made to file"
   },
-  "already-exists": {
-    "defaultMessage": "Тхіс філе алреаду ексістс",
-    "description": "File already exists notification text"
-  },
   "api-description": {
     "defaultMessage": "API documentation for micro:bit MicroPython",
     "description": "Description at the top of the API tab"
@@ -255,6 +251,38 @@
     "defaultMessage": "{name} філе астіонс",
     "description": "Header of file actions for file"
   },
+  "file-already-exists": {
+    "defaultMessage": "This file already exists",
+    "description": "File already exists notification text"
+  },
+  "file-name-invalid-character": {
+    "defaultMessage": "The name contains an invalid character: {invalid}",
+    "description": "Warning text for new Python file name with an invalid character"
+  },
+  "file-name-length": {
+    "defaultMessage": "The name is too long",
+    "description": "Warning text for overly long file names (file system limitation)"
+  },
+  "file-name-lowercase-only": {
+    "defaultMessage": "The name should be all lowercase",
+    "description": "Warning text for new Python file with uppercase"
+  },
+  "file-name-not-blank": {
+    "defaultMessage": "The project name cannot be blank",
+    "description": "Validation message for project name"
+  },
+  "file-name-not-empty": {
+    "defaultMessage": "The name cannot be empty",
+    "description": "Warning text for new Python file with empty name"
+  },
+  "file-name-start-number": {
+    "defaultMessage": "The name cannot start with a number",
+    "description": "Warning text for new Python file names starting with a number"
+  },
+  "file-name-whitespace": {
+    "defaultMessage": "The name cannot contain spaces",
+    "description": "Warning text for new Python file name with whitespace"
+  },
   "firmware-update-link": {
     "defaultMessage": "You must <link>update your firmware</link> before you can connect to this micro:bit.",
     "description": "Text in the firmware update dialog"
@@ -362,10 +390,6 @@
     "defaultMessage": "Лоадіндж…",
     "description": "Shown on loading indicators"
   },
-  "lowercase-no-space": {
-    "defaultMessage": "Путхон філес схоюлд хаве ловерсасе намес вітх но спасес",
-    "description": "Warning text for uppercase Pyton file name or space"
-  },
   "microbit-hearts-alt": {
     "defaultMessage": "місро:біт боард вітх тхе 5 бу 5 ЛEД джрід сховіндж а хеарт",
     "description": "Alt text for micro:bit image in About dialog"
@@ -389,14 +413,6 @@
   "more-download-options": {
     "defaultMessage": "More download options",
     "description": "Aria label for the additional actions menu to the right of the Download/Flash button"
-  },
-  "name-not-blank": {
-    "defaultMessage": "Тхе проджест наме саннот бе бланк",
-    "description": "Validation message for project name"
-  },
-  "name-not-empty": {
-    "defaultMessage": "Тхе наме саннот бе емпту",
-    "description": "Warning text for new Pyton file with empty name"
   },
   "name-project": {
     "defaultMessage": "Наме уоюр проджест",

--- a/src/fs/fs.ts
+++ b/src/fs/fs.ts
@@ -138,6 +138,10 @@ export const EVENT_PROJECT_UPDATED = "project_updated";
 export const EVENT_TEXT_EDIT = "file_text_updated";
 export const MAIN_FILE = "main.py";
 
+export const isNameLengthValid = (filename: string): boolean =>
+  // This length is enforced by the underlying FS so we check it in the UI ahead of time.
+  new TextEncoder().encode(filename).length <= 120;
+
 /**
  * The MicroPython file system adapted for convienient use from the UI.
  *

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -69,12 +69,6 @@
       "value": "changeName"
     }
   ],
-  "already-exists": [
-    {
-      "type": 0,
-      "value": "This file already exists"
-    }
-  ],
   "api-description": [
     {
       "type": 0,
@@ -503,6 +497,58 @@
       "value": " file actions"
     }
   ],
+  "file-already-exists": [
+    {
+      "type": 0,
+      "value": "This file already exists"
+    }
+  ],
+  "file-name-invalid-character": [
+    {
+      "type": 0,
+      "value": "The name contains an invalid character: "
+    },
+    {
+      "type": 1,
+      "value": "invalid"
+    }
+  ],
+  "file-name-length": [
+    {
+      "type": 0,
+      "value": "The name is too long"
+    }
+  ],
+  "file-name-lowercase-only": [
+    {
+      "type": 0,
+      "value": "The name should be all lowercase"
+    }
+  ],
+  "file-name-not-blank": [
+    {
+      "type": 0,
+      "value": "The project name cannot be blank"
+    }
+  ],
+  "file-name-not-empty": [
+    {
+      "type": 0,
+      "value": "The name cannot be empty"
+    }
+  ],
+  "file-name-start-number": [
+    {
+      "type": 0,
+      "value": "The name cannot start with a number"
+    }
+  ],
+  "file-name-whitespace": [
+    {
+      "type": 0,
+      "value": "The name cannot contain spaces"
+    }
+  ],
   "firmware-update-link": [
     {
       "type": 0,
@@ -707,12 +753,6 @@
       "value": "Loading…"
     }
   ],
-  "lowercase-no-space": [
-    {
-      "type": 0,
-      "value": "Python files should have lowercase names with no spaces"
-    }
-  ],
   "microbit-hearts-alt": [
     {
       "type": 0,
@@ -771,18 +811,6 @@
     {
       "type": 0,
       "value": "More download options"
-    }
-  ],
-  "name-not-blank": [
-    {
-      "type": 0,
-      "value": "The project name cannot be blank"
-    }
-  ],
-  "name-not-empty": [
-    {
-      "type": 0,
-      "value": "The name cannot be empty"
     }
   ],
   "name-project": [

--- a/src/messages/fr.json
+++ b/src/messages/fr.json
@@ -69,12 +69,6 @@
       "value": "changeName"
     }
   ],
-  "already-exists": [
-    {
-      "type": 0,
-      "value": "Ce fichier existe déjà"
-    }
-  ],
   "api-description": [
     {
       "type": 0,
@@ -503,6 +497,58 @@
       "value": "name"
     }
   ],
+  "file-already-exists": [
+    {
+      "type": 0,
+      "value": "This file already exists"
+    }
+  ],
+  "file-name-invalid-character": [
+    {
+      "type": 0,
+      "value": "The name contains an invalid character: "
+    },
+    {
+      "type": 1,
+      "value": "invalid"
+    }
+  ],
+  "file-name-length": [
+    {
+      "type": 0,
+      "value": "The name is too long"
+    }
+  ],
+  "file-name-lowercase-only": [
+    {
+      "type": 0,
+      "value": "The name should be all lowercase"
+    }
+  ],
+  "file-name-not-blank": [
+    {
+      "type": 0,
+      "value": "The project name cannot be blank"
+    }
+  ],
+  "file-name-not-empty": [
+    {
+      "type": 0,
+      "value": "The name cannot be empty"
+    }
+  ],
+  "file-name-start-number": [
+    {
+      "type": 0,
+      "value": "The name cannot start with a number"
+    }
+  ],
+  "file-name-whitespace": [
+    {
+      "type": 0,
+      "value": "The name cannot contain spaces"
+    }
+  ],
   "firmware-update-link": [
     {
       "type": 0,
@@ -707,12 +753,6 @@
       "value": "Chargement…"
     }
   ],
-  "lowercase-no-space": [
-    {
-      "type": 0,
-      "value": "Les fichiers Python doivent avoir des noms en minuscules et sans espaces"
-    }
-  ],
   "microbit-hearts-alt": [
     {
       "type": 0,
@@ -771,18 +811,6 @@
     {
       "type": 0,
       "value": "Plus d’options de téléchargement"
-    }
-  ],
-  "name-not-blank": [
-    {
-      "type": 0,
-      "value": "Le nom du projet ne doit pas être laissé vide"
-    }
-  ],
-  "name-not-empty": [
-    {
-      "type": 0,
-      "value": "Le nom ne doit pas être vide"
     }
   ],
   "name-project": [

--- a/src/messages/lol.json
+++ b/src/messages/lol.json
@@ -69,12 +69,6 @@
       "value": "changeName"
     }
   ],
-  "already-exists": [
-    {
-      "type": 0,
-      "value": "Тхіс філе алреаду ексістс"
-    }
-  ],
   "api-description": [
     {
       "type": 0,
@@ -503,6 +497,58 @@
       "value": " філе астіонс"
     }
   ],
+  "file-already-exists": [
+    {
+      "type": 0,
+      "value": "This file already exists"
+    }
+  ],
+  "file-name-invalid-character": [
+    {
+      "type": 0,
+      "value": "The name contains an invalid character: "
+    },
+    {
+      "type": 1,
+      "value": "invalid"
+    }
+  ],
+  "file-name-length": [
+    {
+      "type": 0,
+      "value": "The name is too long"
+    }
+  ],
+  "file-name-lowercase-only": [
+    {
+      "type": 0,
+      "value": "The name should be all lowercase"
+    }
+  ],
+  "file-name-not-blank": [
+    {
+      "type": 0,
+      "value": "The project name cannot be blank"
+    }
+  ],
+  "file-name-not-empty": [
+    {
+      "type": 0,
+      "value": "The name cannot be empty"
+    }
+  ],
+  "file-name-start-number": [
+    {
+      "type": 0,
+      "value": "The name cannot start with a number"
+    }
+  ],
+  "file-name-whitespace": [
+    {
+      "type": 0,
+      "value": "The name cannot contain spaces"
+    }
+  ],
   "firmware-update-link": [
     {
       "type": 0,
@@ -707,12 +753,6 @@
       "value": "Лоадіндж…"
     }
   ],
-  "lowercase-no-space": [
-    {
-      "type": 0,
-      "value": "Путхон філес схоюлд хаве ловерсасе намес вітх но спасес"
-    }
-  ],
   "microbit-hearts-alt": [
     {
       "type": 0,
@@ -771,18 +811,6 @@
     {
       "type": 0,
       "value": "More download options"
-    }
-  ],
-  "name-not-blank": [
-    {
-      "type": 0,
-      "value": "Тхе проджест наме саннот бе бланк"
-    }
-  ],
-  "name-not-empty": [
-    {
-      "type": 0,
-      "value": "Тхе наме саннот бе емпту"
     }
   ],
   "name-project": [

--- a/src/project/project-utils.test.ts
+++ b/src/project/project-utils.test.ts
@@ -2,6 +2,8 @@
  * (c) 2021, Micro:bit Educational Foundation and contributors
  *
  * SPDX-License-Identifier: MIT
+ *
+ * @jest-environment node
  */
 import { validateNewFilename } from "./project-utils";
 import { stubIntl as intl } from "../messages/testing";
@@ -9,26 +11,44 @@ import { stubIntl as intl } from "../messages/testing";
 describe("validateNewFilename", () => {
   const exists = (filename: string) => filename === "main.py";
 
-  it("required non-empty name", () => {
-    expect(validateNewFilename("", exists, intl)).toEqual("name-not-empty");
-  });
-  it("errors for Python extensions", () => {
-    expect(validateNewFilename("foo.py", exists, intl)).toEqual(
-      "lowercase-no-space"
+  it("requires non-empty name", () => {
+    expect(validateNewFilename("", exists, intl)).toEqual(
+      "file-name-not-empty"
     );
+  });
+  it("length", () => {
+    expect(validateNewFilename("a".repeat(121), exists, intl)).toEqual(
+      "file-name-length"
+    );
+    expect(validateNewFilename("a".repeat(120), exists, intl)).toBeUndefined();
+  });
+  it("no error for Python extensions", () => {
+    expect(validateNewFilename("foo.py", exists, intl)).toBeUndefined();
   });
   it("errors for spaces", () => {
     expect(validateNewFilename("spaces are not allowed", exists, intl)).toEqual(
-      "lowercase-no-space"
+      "file-name-whitespace"
+    );
+  });
+  it("errors for other invalid chars", () => {
+    expect(validateNewFilename("wow!64", exists, intl)).toEqual(
+      "file-name-invalid-character"
+    );
+  });
+  it("errors for leading number", () => {
+    expect(validateNewFilename("99greenbottles", exists, intl)).toEqual(
+      "file-name-start-number"
     );
   });
   it("errors for uppercase", () => {
     expect(validateNewFilename("OHNO", exists, intl)).toEqual(
-      "lowercase-no-space"
+      "file-name-lowercase-only"
     );
   });
   it("errors for file clashes", () => {
-    expect(validateNewFilename("main", exists, intl)).toEqual("already-exists");
+    expect(validateNewFilename("main", exists, intl)).toEqual(
+      "file-already-exists"
+    );
   });
   it("accepts valid names", () => {
     expect(

--- a/src/project/project-utils.ts
+++ b/src/project/project-utils.ts
@@ -5,6 +5,7 @@
  */
 import { getLowercaseFileExtension } from "../fs/fs-util";
 import { IntlShape } from "react-intl";
+import { isNameLengthValid } from "../fs/fs";
 
 export const isPythonFile = (filename: string) =>
   getLowercaseFileExtension(filename) === "py";
@@ -16,10 +17,12 @@ export const ensurePythonExtension = (filename: string) =>
 export const isEditableFile = isPythonFile;
 
 /**
- * From https://www.python.org/dev/peps/pep-0008/#package-and-module-names
+ * Constraints:
  *
- * "Modules should have short, all-lowercase names.
- * Underscores can be used in the module name if it improves readability."
+ * 1. What can be created as a file in MicroPython's file system.
+ * 2. What can be referenced via an import in the grammar, but as it's
+ *    decidedly non-trivial, we've gone with a simplified version.
+ * 3. Modules should have short, all-lowercase names (PEP8)
  *
  * @param filename The name to check. May be user input without a file extension.
  * @param exists A function to check whether a file exists.
@@ -29,14 +32,41 @@ export const validateNewFilename = (
   exists: (f: string) => boolean,
   intl: IntlShape
 ): string | undefined => {
-  if (filename.length === 0) {
-    return intl.formatMessage({ id: "name-not-empty" });
+  // It's valid with or without the extension. Run checks without.
+  if (isPythonFile(filename)) {
+    filename = filename.slice(0, -".py".length);
   }
-  if (!filename.match(/^[\p{Ll}_]+$/u)) {
-    return intl.formatMessage({ id: "lowercase-no-space" });
+
+  if (filename.length === 0) {
+    return intl.formatMessage({ id: "file-name-not-empty" });
+  }
+  if (!isNameLengthValid(filename)) {
+    return intl.formatMessage({ id: "file-name-length" });
+  }
+  if (filename.match(/\s/)) {
+    return intl.formatMessage({ id: "file-name-whitespace" });
+  }
+  // This includes Unicode ranges that we should exclude, but it's
+  // probably not worth the bundle size to do this correctly.
+  // If we revisit see Pyright's implementation.
+  const invalidCharMatch = /[^a-zA-Z0-9_\u{a1}-\u{10ffff}]/u.exec(filename);
+  if (invalidCharMatch) {
+    return intl.formatMessage(
+      { id: "file-name-invalid-character" },
+      {
+        invalid: invalidCharMatch[0],
+      }
+    );
+  }
+  if (filename.match("^[0-9]")) {
+    return intl.formatMessage({ id: "file-name-start-number" });
+  }
+  // This one is PEP8 so we can drop it if it causes folks practical issues.
+  if (filename.match("[A-Z]")) {
+    return intl.formatMessage({ id: "file-name-lowercase-only" });
   }
   if (exists(ensurePythonExtension(filename))) {
-    return intl.formatMessage({ id: "already-exists" });
+    return intl.formatMessage({ id: "file-already-exists" });
   }
   return undefined;
 };


### PR DESCRIPTION
We haven't checked the exact unicode ranges as that's quite involved but
this should generally be more accurate and no longer ban numbers or
characters from languages without an upper/lowercase distinction.

Closes https://github.com/microbit-foundation/python-editor-next/issues/524
Closes https://github.com/microbit-foundation/python-editor-next/issues/531