### PR TITLE
Rename Download -> Save.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ _steps:
   install_dependencies: &install_dependencies
     run: npm ci --cache .npm-cache && sudo npm config set @microbit-foundation:registry https://npm.pkg.github.com/microbit-foundation && sudo npm i -g @microbit-foundation/website-deploy-aws@0.3.0 @microbit-foundation/website-deploy-aws-config@0.4.2 @microbit-foundation/circleci-npm-package-versioner@1
   install_theme: &install_theme
-    run: npm config set @microbit-foundation:registry https://npm.pkg.github.com/microbit-foundation && npm install --no-save @microbit-foundation/python-editor-next-microbit@0.1.0-dev.148
+    run: npm config set @microbit-foundation:registry https://npm.pkg.github.com/microbit-foundation && npm install --no-save @microbit-foundation/python-editor-next-microbit@0.1.0-dev.154
   update_version: &update_version
     run: npm run ci:update-version
   build: &build

--- a/lang/en.json
+++ b/lang/en.json
@@ -127,10 +127,6 @@
     "defaultMessage": "Confirm delete",
     "description": "Confirmation header of deletion of a file"
   },
-  "confirm-download-action": {
-    "defaultMessage": "Confirm and download",
-    "description": "Confirm and download action label"
-  },
   "confirm-replace-body": {
     "defaultMessage": "Replace all files with those in the hex?",
     "description": "Confirmation message body for replacing project dialog"
@@ -142,6 +138,10 @@
   "confirm-replace-with-idea": {
     "defaultMessage": "Replace all files with {ideaName}?",
     "description": "Confirmation message body for replacing project dialog with an idea"
+  },
+  "confirm-save-action": {
+    "defaultMessage": "Confirm and save",
+    "description": "Confirm and save action label"
   },
   "connect-action": {
     "defaultMessage": "Connect",
@@ -234,26 +234,6 @@
   "dont-show-again": {
     "defaultMessage": "Don't show this again",
     "description": "Text to never show a dialog again"
-  },
-  "download-action": {
-    "defaultMessage": "Download",
-    "description": "Download button text"
-  },
-  "download-file-action": {
-    "defaultMessage": "Download {name}",
-    "description": "Menu option to download file"
-  },
-  "download-hex-action": {
-    "defaultMessage": "Download project hex",
-    "description": "Text for menu item for downloading project hex file"
-  },
-  "download-hover": {
-    "defaultMessage": "Download a project hex file",
-    "description": "Hover text over download button"
-  },
-  "download-python-action": {
-    "defaultMessage": "Download Python script",
-    "description": "Download button menu option for downloading Python script"
   },
   "drag-hover": {
     "defaultMessage": "Drag and drop",
@@ -439,9 +419,9 @@
     "defaultMessage": "More connect options",
     "description": "Aria label for the additional actions menu to the right of the Send to micro:bit button"
   },
-  "more-download-options": {
-    "defaultMessage": "More download options",
-    "description": "Aria label for the additional actions menu to the right of the Download/Flash button"
+  "more-save-options": {
+    "defaultMessage": "More save options",
+    "description": "Aria label for the additional actions menu to the right of the Save button"
   },
   "name-project": {
     "defaultMessage": "Name your project",
@@ -452,7 +432,7 @@
     "description": "Header for name field"
   },
   "name-used-when": {
-    "defaultMessage": "The name is used when you download a hex file.",
+    "defaultMessage": "The name is used when you save a hex file.",
     "description": "Text under project name field"
   },
   "new-file-hint": {
@@ -471,13 +451,13 @@
     "defaultMessage": "If you have a <strong>micro:bit V1</strong> you may need to <link>update the firmware</link>",
     "description": "Checklist text in the no micro:bit found dialog"
   },
-  "not-found-download-message": {
-    "defaultMessage": "Alternative method: choose Download",
-    "description": "Download text prompt in the no micro:bit found dialog"
-  },
   "not-found-message": {
     "defaultMessage": "You didn’t select a micro:bit, or there was a problem connecting to it.",
     "description": "Text in the no micro:bit found dialog"
+  },
+  "not-found-save-message": {
+    "defaultMessage": "Alternative method: choose Save then follow steps to transfer",
+    "description": "Save prompt in the no micro:bit found dialog"
   },
   "not-found-title": {
     "defaultMessage": "No micro:bit found",
@@ -578,6 +558,26 @@
   "results-count": {
     "defaultMessage": "{count, plural, =0 {No results} one {# result} other {# results}}",
     "description": "Number of results from a search"
+  },
+  "save-action": {
+    "defaultMessage": "Save",
+    "description": "Save button text"
+  },
+  "save-file-action": {
+    "defaultMessage": "Save {name}",
+    "description": "Menu option to save a file"
+  },
+  "save-hex-action": {
+    "defaultMessage": "Save project hex",
+    "description": "Text for menu item for saving a project hex file"
+  },
+  "save-hover": {
+    "defaultMessage": "Save the project hex file to your computer",
+    "description": "Hover text over save button"
+  },
+  "save-python-action": {
+    "defaultMessage": "Save Python script",
+    "description": "Save button menu option to save the Python script"
   },
   "search": {
     "defaultMessage": "Search",
@@ -724,7 +724,7 @@
     "description": "Text in the transfer hex dialog"
   },
   "transfer-hex-title": {
-    "defaultMessage": "Transfer downloaded hex file to micro:bit",
+    "defaultMessage": "Transfer saved hex file to micro:bit",
     "description": "Title for the transfer hex dialog"
   },
   "try-again-action": {
@@ -759,10 +759,6 @@
     "defaultMessage": "visit microbit.org (opens in a new tab)",
     "description": "alt text for logo link to .org"
   },
-  "webusb-download-instead": {
-    "defaultMessage": "Download the hex file or try Chrome or Microsoft Edge.",
-    "description": "Shown from the connect action when the user's browser doesn't support WebUSB."
-  },
   "webusb-error-clear-connect-description-1": {
     "defaultMessage": "Another process is connected to this device.",
     "description": "Part of WebUSB error message"
@@ -792,7 +788,7 @@
     "description": "Error text telling user to update firmware"
   },
   "webusb-not-supported": {
-    "defaultMessage": "Unfortunately, WebUSB is not supported in this browser and your program will be downloaded instead. We recommend Chrome or Microsoft Edge so you can connect directly to your micro:bit.",
+    "defaultMessage": "Unfortunately, WebUSB is not supported in this browser and your program will be saved instead. We recommend Google Chrome or Microsoft Edge so you can connect directly to your micro:bit.",
     "description": "Shown when user's browser doesn't support WebUSB"
   },
   "webusb-why-use": {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -127,10 +127,6 @@
     "defaultMessage": "Confirmer la suppression",
     "description": "Confirmation header of deletion of a file"
   },
-  "confirm-download-action": {
-    "defaultMessage": "Confirm and download",
-    "description": "Confirm and download action label"
-  },
   "confirm-replace-body": {
     "defaultMessage": "Remplacer tous les fichiers par ceux de l’hex ?",
     "description": "Confirmation message body for replacing project dialog"
@@ -142,6 +138,10 @@
   "confirm-replace-with-idea": {
     "defaultMessage": "Replace all files with {ideaName}?",
     "description": "Confirmation message body for replacing project dialog with an idea"
+  },
+  "confirm-save-action": {
+    "defaultMessage": "Confirm and save",
+    "description": "Confirm and save action label"
   },
   "connect-action": {
     "defaultMessage": "Connecter",
@@ -234,26 +234,6 @@
   "dont-show-again": {
     "defaultMessage": "Don't show this again",
     "description": "Text to never show a dialog again"
-  },
-  "download-action": {
-    "defaultMessage": "Télécharger",
-    "description": "Download button text"
-  },
-  "download-file-action": {
-    "defaultMessage": "Télécharger {name}",
-    "description": "Menu option to download file"
-  },
-  "download-hex-action": {
-    "defaultMessage": "Télécharger l’hex du projet",
-    "description": "Text for menu item for downloading project hex file"
-  },
-  "download-hover": {
-    "defaultMessage": "Télécharger le fichier hex d’un projet",
-    "description": "Hover text over download button"
-  },
-  "download-python-action": {
-    "defaultMessage": "Télécharger le script Python",
-    "description": "Download button menu option for downloading Python script"
   },
   "drag-hover": {
     "defaultMessage": "Drag and drop",
@@ -438,9 +418,9 @@
     "defaultMessage": "More connect options",
     "description": "Aria label for the additional actions menu to the right of the Send to micro:bit button"
   },
-  "more-download-options": {
-    "defaultMessage": "Plus d’options de téléchargement",
-    "description": "Aria label for the additional actions menu to the right of the Download/Flash button"
+  "more-save-options": {
+    "defaultMessage": "More save options",
+    "description": "Aria label for the additional actions menu to the right of the Save button"
   },
   "name-project": {
     "defaultMessage": "Donnez un nom à votre projet",
@@ -470,13 +450,13 @@
     "defaultMessage": "Check your micro:bit is plugged in and powered on",
     "description": "Checklist text in the no micro:bit found dialog"
   },
-  "not-found-download-message": {
-    "defaultMessage": "Alternative method: choose Download",
-    "description": "Download text prompt in the no micro:bit found dialog"
-  },
   "not-found-message": {
     "defaultMessage": "You didn’t select a micro:bit, or there was a problem connecting to it.",
     "description": "Text in the no micro:bit found dialog"
+  },
+  "not-found-save-message": {
+    "defaultMessage": "Alternative method: choose Save",
+    "description": "Save prompt in the no micro:bit found dialog"
   },
   "not-found-title": {
     "defaultMessage": "No micro:bit found",
@@ -577,6 +557,26 @@
   "results-count": {
     "defaultMessage": "{count, plural, =0 {Aucun résultat} one {# résultat} other {# résultats}}",
     "description": "Number of results from a search"
+  },
+  "save-action": {
+    "defaultMessage": "Save",
+    "description": "Save button text"
+  },
+  "save-file-action": {
+    "defaultMessage": "Save {name}",
+    "description": "Menu option to save a file"
+  },
+  "save-hex-action": {
+    "defaultMessage": "Save project hex",
+    "description": "Text for menu item for saving a project hex file"
+  },
+  "save-hover": {
+    "defaultMessage": "Save a project hex file to your computer",
+    "description": "Hover text over save button"
+  },
+  "save-python-action": {
+    "defaultMessage": "Save Python script to your computer",
+    "description": "Save button menu option to save a Python script"
   },
   "search": {
     "defaultMessage": "Rechercher",
@@ -757,10 +757,6 @@
   "visit-dot-org": {
     "defaultMessage": "visiter microbit.org (s’ouvre dans un nouvel onglet)",
     "description": "alt text for logo link to .org"
-  },
-  "webusb-download-instead": {
-    "defaultMessage": "Téléchargez le fichier hex ou essayez Chrome ou Microsoft Edge.",
-    "description": "Shown from the connect action when the user's browser doesn't support WebUSB."
   },
   "webusb-error-clear-connect-description-1": {
     "defaultMessage": "Un autre processus est connecté à cet appareil.",

--- a/lang/lol.json
+++ b/lang/lol.json
@@ -127,10 +127,6 @@
     "defaultMessage": "Cонфірм делете",
     "description": "Confirmation header of deletion of a file"
   },
-  "confirm-download-action": {
-    "defaultMessage": "Confirm and download",
-    "description": "Confirm and download action label"
-  },
   "confirm-replace-body": {
     "defaultMessage": "Репласе алл філес вітх тхосе ін тхе хекс?",
     "description": "Confirmation message body for replacing project dialog"
@@ -142,6 +138,10 @@
   "confirm-replace-with-idea": {
     "defaultMessage": "Replace all files with {ideaName}?",
     "description": "Confirmation message body for replacing project dialog with an idea"
+  },
+  "confirm-save-action": {
+    "defaultMessage": "Confirm and save",
+    "description": "Confirm and save action label"
   },
   "connect-action": {
     "defaultMessage": "Cоннест",
@@ -234,26 +234,6 @@
   "dont-show-again": {
     "defaultMessage": "Don't show this again",
     "description": "Text to never show a dialog again"
-  },
-  "download-action": {
-    "defaultMessage": "Довнлоад",
-    "description": "Download button text"
-  },
-  "download-file-action": {
-    "defaultMessage": "Довнлоад {name}",
-    "description": "Menu option to download file"
-  },
-  "download-hex-action": {
-    "defaultMessage": "Довнлоад проджест хекс",
-    "description": "Text for menu item for downloading project hex file"
-  },
-  "download-hover": {
-    "defaultMessage": "Довнлоад а проджест хекс філе",
-    "description": "Hover text over download button"
-  },
-  "download-python-action": {
-    "defaultMessage": "Довнлоад Путхон ссріпт",
-    "description": "Download button menu option for downloading Python script"
   },
   "drag-hover": {
     "defaultMessage": "Drag and drop",
@@ -438,9 +418,9 @@
     "defaultMessage": "More connect options",
     "description": "Aria label for the additional actions menu to the right of the Send to micro:bit button"
   },
-  "more-download-options": {
-    "defaultMessage": "More download options",
-    "description": "Aria label for the additional actions menu to the right of the Download/Flash button"
+  "more-save-options": {
+    "defaultMessage": "More save options",
+    "description": "Aria label for the additional actions menu to the right of the Save button"
   },
   "name-project": {
     "defaultMessage": "Наме уоюр проджест",
@@ -470,13 +450,13 @@
     "defaultMessage": "Check your micro:bit is plugged in and powered on",
     "description": "Checklist text in the no micro:bit found dialog"
   },
-  "not-found-download-message": {
-    "defaultMessage": "Alternative method: choose Download",
-    "description": "Download text prompt in the no micro:bit found dialog"
-  },
   "not-found-message": {
     "defaultMessage": "You didn’t select a micro:bit, or there was a problem connecting to it.",
     "description": "Text in the no micro:bit found dialog"
+  },
+  "not-found-save-message": {
+    "defaultMessage": "Alternative method: choose Save",
+    "description": "Save prompt in the no micro:bit found dialog"
   },
   "not-found-title": {
     "defaultMessage": "No micro:bit found",
@@ -577,6 +557,26 @@
   "results-count": {
     "defaultMessage": "{count, plural, =0 {No results} one {# result} other {# results}}",
     "description": "Number of results from a search"
+  },
+  "save-action": {
+    "defaultMessage": "Save",
+    "description": "Save button text"
+  },
+  "save-file-action": {
+    "defaultMessage": "Save {name}",
+    "description": "Menu option to save a file"
+  },
+  "save-hex-action": {
+    "defaultMessage": "Save project hex",
+    "description": "Text for menu item for saving a project hex file"
+  },
+  "save-hover": {
+    "defaultMessage": "Save a project hex file to your computer",
+    "description": "Hover text over save button"
+  },
+  "save-python-action": {
+    "defaultMessage": "Save Python script to your computer",
+    "description": "Save button menu option to save a Python script"
   },
   "search": {
     "defaultMessage": "Search",
@@ -757,10 +757,6 @@
   "visit-dot-org": {
     "defaultMessage": "вісіт місробіт.ордж (опенс ін а нев таб)",
     "description": "alt text for logo link to .org"
-  },
-  "webusb-download-instead": {
-    "defaultMessage": "Довнлоад тхе хекс філе ор тру Cхроме ор Місрософт Eддже.",
-    "description": "Shown from the connect action when the user's browser doesn't support WebUSB."
   },
   "webusb-error-clear-connect-description-1": {
     "defaultMessage": "Анотхер просесс іс соннестед то тхіс девісе.",

--- a/src/e2e/app.ts
+++ b/src/e2e/app.ts
@@ -623,15 +623,15 @@ export class App {
   }
 
   /**
-   * Trigger a download but don't wait for it to complete.
+   * Trigger a save but don't wait for it to complete.
    *
    * Useful when the action is expected to fail.
-   * Otherwise see waitForDownload.
+   * Otherwise see waitForSave.
    */
-  async download(): Promise<void> {
+  async save(): Promise<void> {
     const document = await this.document();
-    const downloadButton = await document.getByText("Download");
-    return downloadButton.click();
+    const saveButton = await document.getByText("Save");
+    return saveButton.click();
   }
 
   async connect(): Promise<void> {
@@ -699,7 +699,7 @@ export class App {
 
   async confirmTransferHexHelpDialog(): Promise<void> {
     const document = await this.document();
-    await document.findByText("Transfer downloaded hex file to micro:bit", {
+    await document.findByText("Transfer saved hex file to micro:bit", {
       selector: "h2",
     });
   }
@@ -796,12 +796,12 @@ export class App {
   }
 
   /**
-   * Trigger a download and wait for it to complete.
+   * Trigger a hex file save and wait for the download to complete.
    *
    * @returns Download details.
    */
-  async waitForDownload(): Promise<BrowserDownload> {
-    return this.waitForDownloadOnDisk(() => this.download());
+  async waitForSave(): Promise<BrowserDownload> {
+    return this.waitForDownloadOnDisk(() => this.save());
   }
 
   /**

--- a/src/e2e/save.test.ts
+++ b/src/e2e/save.test.ts
@@ -5,28 +5,28 @@
  */
 import { App, LoadDialogType } from "./app";
 
-describe("Browser - download", () => {
+describe("Browser - save", () => {
   const app = new App();
   beforeEach(app.reset.bind(app));
   afterEach(app.screenshot.bind(app));
   afterAll(app.dispose.bind(app));
 
-  it("Download - download the default HEX asd", async () => {
+  it("Download - save the default HEX asd", async () => {
     await app.setProjectName("idiosyncratic ruminant");
-    const download = await app.waitForDownload();
+    const download = await app.waitForSave();
 
     expect(download.filename).toEqual("idiosyncratic ruminant.hex");
     expect(download.data.toString("ascii")).toMatch(/^:020000040000FA/);
   });
 
-  it("Shows an error when trying to download a hex file if the Python code is too large", async () => {
+  it("Shows an error when trying to save a hex file if the Python code is too large", async () => {
     // Set the project name to avoid calling the edit project name input dialog.
     await app.setProjectName("not default name");
     await app.loadFiles("testData/too-large.py", {
       acceptDialog: LoadDialogType.CONFIRM,
     });
     await app.findVisibleEditorContents(/# Filler/);
-    await app.download();
+    await app.save();
 
     await app.findAlertText(
       "Failed to build the hex file",
@@ -35,13 +35,13 @@ describe("Browser - download", () => {
   });
 
   it("Shows the name your project dialog if the project name is the default", async () => {
-    await app.download();
+    await app.save();
     await app.confirmNameYourProjectDialog();
   });
 
-  it("Shows the transfer hex help dialog after hex download", async () => {
+  it("Shows the transfer hex help dialog after hex save", async () => {
     await app.setProjectName("not default name");
-    await app.download();
+    await app.save();
     await app.confirmTransferHexHelpDialog();
   });
 });

--- a/src/fs/fs.test.ts
+++ b/src/fs/fs.test.ts
@@ -196,7 +196,7 @@ describe("Filesystem", () => {
     await ufs.write("big.dat", data, VersionAction.INCREMENT);
 
     // But not if you ask for the hex.
-    await expect(() => ufs.toHexForDownload()).rejects.toThrow(
+    await expect(() => ufs.toHexForSave()).rejects.toThrow(
       /There is no storage space left./
     );
   });
@@ -208,14 +208,14 @@ describe("Filesystem", () => {
     await ufs.write(MAIN_FILE, data, VersionAction.MAINTAIN);
 
     // But not if you ask for the hex.
-    await expect(() => ufs.toHexForDownload()).rejects.toThrow(
+    await expect(() => ufs.toHexForSave()).rejects.toThrow(
       /There is no storage space left./
     );
   });
 
-  it("creates a universal hex for download", async () => {
+  it("creates a universal hex for save", async () => {
     await ufs.setProjectName("test project name");
-    const data = await ufs.toHexForDownload();
+    const data = await ufs.toHexForSave();
 
     expect(typeof data).toEqual("string");
   });

--- a/src/fs/fs.ts
+++ b/src/fs/fs.ts
@@ -423,7 +423,7 @@ export class FileSystem extends EventEmitter implements FlashDataSource {
     this.emit(EVENT_PROJECT_UPDATED, this.project);
   }
 
-  async toHexForDownload(): Promise<string> {
+  async toHexForSave(): Promise<string> {
     const fs = await this.initialize();
     return fs.getUniversalHex();
   }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -287,12 +287,6 @@
       "value": "Confirm delete"
     }
   ],
-  "confirm-download-action": [
-    {
-      "type": 0,
-      "value": "Confirm and download"
-    }
-  ],
   "confirm-replace-body": [
     {
       "type": 0,
@@ -317,6 +311,12 @@
     {
       "type": 0,
       "value": "?"
+    }
+  ],
+  "confirm-save-action": [
+    {
+      "type": 0,
+      "value": "Confirm and save"
     }
   ],
   "connect-action": [
@@ -467,40 +467,6 @@
     {
       "type": 0,
       "value": "Don't show this again"
-    }
-  ],
-  "download-action": [
-    {
-      "type": 0,
-      "value": "Download"
-    }
-  ],
-  "download-file-action": [
-    {
-      "type": 0,
-      "value": "Download "
-    },
-    {
-      "type": 1,
-      "value": "name"
-    }
-  ],
-  "download-hex-action": [
-    {
-      "type": 0,
-      "value": "Download project hex"
-    }
-  ],
-  "download-hover": [
-    {
-      "type": 0,
-      "value": "Download a project hex file"
-    }
-  ],
-  "download-python-action": [
-    {
-      "type": 0,
-      "value": "Download Python script"
     }
   ],
   "drag-hover": [
@@ -857,10 +823,10 @@
       "value": "More connect options"
     }
   ],
-  "more-download-options": [
+  "more-save-options": [
     {
       "type": 0,
-      "value": "More download options"
+      "value": "More save options"
     }
   ],
   "name-project": [
@@ -878,7 +844,7 @@
   "name-used-when": [
     {
       "type": 0,
-      "value": "The name is used when you download a hex file."
+      "value": "The name is used when you save a hex file."
     }
   ],
   "new-file-hint": [
@@ -971,16 +937,16 @@
       "value": "link"
     }
   ],
-  "not-found-download-message": [
-    {
-      "type": 0,
-      "value": "Alternative method: choose Download"
-    }
-  ],
   "not-found-message": [
     {
       "type": 0,
       "value": "You didn’t select a micro:bit, or there was a problem connecting to it."
+    }
+  ],
+  "not-found-save-message": [
+    {
+      "type": 0,
+      "value": "Alternative method: choose Save then follow steps to transfer"
     }
   ],
   "not-found-title": [
@@ -1195,6 +1161,40 @@
       "pluralType": "cardinal",
       "type": 6,
       "value": "count"
+    }
+  ],
+  "save-action": [
+    {
+      "type": 0,
+      "value": "Save"
+    }
+  ],
+  "save-file-action": [
+    {
+      "type": 0,
+      "value": "Save "
+    },
+    {
+      "type": 1,
+      "value": "name"
+    }
+  ],
+  "save-hex-action": [
+    {
+      "type": 0,
+      "value": "Save project hex"
+    }
+  ],
+  "save-hover": [
+    {
+      "type": 0,
+      "value": "Save the project hex file to your computer"
+    }
+  ],
+  "save-python-action": [
+    {
+      "type": 0,
+      "value": "Save Python script"
     }
   ],
   "search": [
@@ -1558,7 +1558,7 @@
   "transfer-hex-title": [
     {
       "type": 0,
-      "value": "Transfer downloaded hex file to micro:bit"
+      "value": "Transfer saved hex file to micro:bit"
     }
   ],
   "try-again-action": [
@@ -1633,12 +1633,6 @@
       "value": "visit microbit.org (opens in a new tab)"
     }
   ],
-  "webusb-download-instead": [
-    {
-      "type": 0,
-      "value": "Download the hex file or try Chrome or Microsoft Edge."
-    }
-  ],
   "webusb-error-clear-connect-description-1": [
     {
       "type": 0,
@@ -1698,7 +1692,7 @@
   "webusb-not-supported": [
     {
       "type": 0,
-      "value": "Unfortunately, WebUSB is not supported in this browser and your program will be downloaded instead. We recommend Chrome or Microsoft Edge so you can connect directly to your micro:bit."
+      "value": "Unfortunately, WebUSB is not supported in this browser and your program will be saved instead. We recommend Google Chrome or Microsoft Edge so you can connect directly to your micro:bit."
     }
   ],
   "webusb-why-use": [

--- a/src/messages/fr.json
+++ b/src/messages/fr.json
@@ -287,12 +287,6 @@
       "value": "Confirmer la suppression"
     }
   ],
-  "confirm-download-action": [
-    {
-      "type": 0,
-      "value": "Confirm and download"
-    }
-  ],
   "confirm-replace-body": [
     {
       "type": 0,
@@ -317,6 +311,12 @@
     {
       "type": 0,
       "value": "?"
+    }
+  ],
+  "confirm-save-action": [
+    {
+      "type": 0,
+      "value": "Confirm and save"
     }
   ],
   "connect-action": [
@@ -467,40 +467,6 @@
     {
       "type": 0,
       "value": "Don't show this again"
-    }
-  ],
-  "download-action": [
-    {
-      "type": 0,
-      "value": "Télécharger"
-    }
-  ],
-  "download-file-action": [
-    {
-      "type": 0,
-      "value": "Télécharger "
-    },
-    {
-      "type": 1,
-      "value": "name"
-    }
-  ],
-  "download-hex-action": [
-    {
-      "type": 0,
-      "value": "Télécharger l’hex du projet"
-    }
-  ],
-  "download-hover": [
-    {
-      "type": 0,
-      "value": "Télécharger le fichier hex d’un projet"
-    }
-  ],
-  "download-python-action": [
-    {
-      "type": 0,
-      "value": "Télécharger le script Python"
     }
   ],
   "drag-hover": [
@@ -857,10 +823,10 @@
       "value": "More connect options"
     }
   ],
-  "more-download-options": [
+  "more-save-options": [
     {
       "type": 0,
-      "value": "Plus d’options de téléchargement"
+      "value": "More save options"
     }
   ],
   "name-project": [
@@ -929,16 +895,16 @@
       "value": "Check your micro:bit is plugged in and powered on"
     }
   ],
-  "not-found-download-message": [
-    {
-      "type": 0,
-      "value": "Alternative method: choose Download"
-    }
-  ],
   "not-found-message": [
     {
       "type": 0,
       "value": "You didn’t select a micro:bit, or there was a problem connecting to it."
+    }
+  ],
+  "not-found-save-message": [
+    {
+      "type": 0,
+      "value": "Alternative method: choose Save"
     }
   ],
   "not-found-title": [
@@ -1153,6 +1119,40 @@
       "pluralType": "cardinal",
       "type": 6,
       "value": "count"
+    }
+  ],
+  "save-action": [
+    {
+      "type": 0,
+      "value": "Save"
+    }
+  ],
+  "save-file-action": [
+    {
+      "type": 0,
+      "value": "Save "
+    },
+    {
+      "type": 1,
+      "value": "name"
+    }
+  ],
+  "save-hex-action": [
+    {
+      "type": 0,
+      "value": "Save project hex"
+    }
+  ],
+  "save-hover": [
+    {
+      "type": 0,
+      "value": "Save a project hex file to your computer"
+    }
+  ],
+  "save-python-action": [
+    {
+      "type": 0,
+      "value": "Save Python script to your computer"
     }
   ],
   "search": [
@@ -1589,12 +1589,6 @@
     {
       "type": 0,
       "value": "visiter microbit.org (s’ouvre dans un nouvel onglet)"
-    }
-  ],
-  "webusb-download-instead": [
-    {
-      "type": 0,
-      "value": "Téléchargez le fichier hex ou essayez Chrome ou Microsoft Edge."
     }
   ],
   "webusb-error-clear-connect-description-1": [

--- a/src/messages/lol.json
+++ b/src/messages/lol.json
@@ -287,12 +287,6 @@
       "value": "Cонфірм делете"
     }
   ],
-  "confirm-download-action": [
-    {
-      "type": 0,
-      "value": "Confirm and download"
-    }
-  ],
   "confirm-replace-body": [
     {
       "type": 0,
@@ -317,6 +311,12 @@
     {
       "type": 0,
       "value": "?"
+    }
+  ],
+  "confirm-save-action": [
+    {
+      "type": 0,
+      "value": "Confirm and save"
     }
   ],
   "connect-action": [
@@ -467,40 +467,6 @@
     {
       "type": 0,
       "value": "Don't show this again"
-    }
-  ],
-  "download-action": [
-    {
-      "type": 0,
-      "value": "Довнлоад"
-    }
-  ],
-  "download-file-action": [
-    {
-      "type": 0,
-      "value": "Довнлоад "
-    },
-    {
-      "type": 1,
-      "value": "name"
-    }
-  ],
-  "download-hex-action": [
-    {
-      "type": 0,
-      "value": "Довнлоад проджест хекс"
-    }
-  ],
-  "download-hover": [
-    {
-      "type": 0,
-      "value": "Довнлоад а проджест хекс філе"
-    }
-  ],
-  "download-python-action": [
-    {
-      "type": 0,
-      "value": "Довнлоад Путхон ссріпт"
     }
   ],
   "drag-hover": [
@@ -857,10 +823,10 @@
       "value": "More connect options"
     }
   ],
-  "more-download-options": [
+  "more-save-options": [
     {
       "type": 0,
-      "value": "More download options"
+      "value": "More save options"
     }
   ],
   "name-project": [
@@ -929,16 +895,16 @@
       "value": "Check your micro:bit is plugged in and powered on"
     }
   ],
-  "not-found-download-message": [
-    {
-      "type": 0,
-      "value": "Alternative method: choose Download"
-    }
-  ],
   "not-found-message": [
     {
       "type": 0,
       "value": "You didn’t select a micro:bit, or there was a problem connecting to it."
+    }
+  ],
+  "not-found-save-message": [
+    {
+      "type": 0,
+      "value": "Alternative method: choose Save"
     }
   ],
   "not-found-title": [
@@ -1153,6 +1119,40 @@
       "pluralType": "cardinal",
       "type": 6,
       "value": "count"
+    }
+  ],
+  "save-action": [
+    {
+      "type": 0,
+      "value": "Save"
+    }
+  ],
+  "save-file-action": [
+    {
+      "type": 0,
+      "value": "Save "
+    },
+    {
+      "type": 1,
+      "value": "name"
+    }
+  ],
+  "save-hex-action": [
+    {
+      "type": 0,
+      "value": "Save project hex"
+    }
+  ],
+  "save-hover": [
+    {
+      "type": 0,
+      "value": "Save a project hex file to your computer"
+    }
+  ],
+  "save-python-action": [
+    {
+      "type": 0,
+      "value": "Save Python script to your computer"
     }
   ],
   "search": [
@@ -1589,12 +1589,6 @@
     {
       "type": 0,
       "value": "вісіт місробіт.ордж (опенс ін а нев таб)"
-    }
-  ],
-  "webusb-download-instead": [
-    {
-      "type": 0,
-      "value": "Довнлоад тхе хекс філе ор тру Cхроме ор Місрософт Eддже."
     }
   ],
   "webusb-error-clear-connect-description-1": [

--- a/src/project/FileRow.tsx
+++ b/src/project/FileRow.tsx
@@ -72,9 +72,9 @@ const FileRow = ({ projectName, value, onEdit, ...props }: FileRowProps) => {
             </MenuItem>
             <MenuItem
               icon={<RiDownload2Line />}
-              onClick={() => actions.downloadFile(name)}
+              onClick={() => actions.saveFile(name)}
             >
-              <FormattedMessage id="download-file-action" values={{ name }} />
+              <FormattedMessage id="save-file-action" values={{ name }} />
             </MenuItem>
             <MenuItem
               icon={<RiDeleteBin2Line />}

--- a/src/project/ProjectActionBar.tsx
+++ b/src/project/ProjectActionBar.tsx
@@ -5,7 +5,7 @@
  */
 import { BoxProps, HStack } from "@chakra-ui/react";
 import SendButton from "./SendButton";
-import DownloadMenuButton from "./DownloadMenuButton";
+import SaveMenuButton from "./SaveMenuButton";
 import OpenButton from "./OpenButton";
 
 const ProjectActionBar = (props: BoxProps) => {
@@ -21,7 +21,7 @@ const ProjectActionBar = (props: BoxProps) => {
     >
       <SendButton size={size} />
       <HStack spacing={2.5}>
-        <DownloadMenuButton size={size} />
+        <SaveMenuButton size={size} />
         {/* Min-width to avoid collapsing when out of space. Needs some work on responsiveness of the action bar. */}
         <OpenButton mode="button" size={size} minW="fit-content" />
       </HStack>

--- a/src/project/SaveButton.tsx
+++ b/src/project/SaveButton.tsx
@@ -11,18 +11,18 @@ import CollapsibleButton, {
 } from "../common/CollapsibleButton";
 import { useProjectActions } from "./project-hooks";
 
-interface DownloadButtonProps
+interface SaveButtonProps
   extends Omit<CollapsibleButtonProps, "onClick" | "text" | "icon"> {}
 
 /**
- * Download HEX button.
+ * Save HEX button.
  *
  * This is the main action for programming the micro:bit if the
  * system does not support WebUSB.
  *
  * Otherwise it's a more minor action.
  */
-const DownloadButton = (props: DownloadButtonProps) => {
+const SaveButton = (props: SaveButtonProps) => {
   const actions = useProjectActions();
   const intl = useIntl();
   return (
@@ -30,19 +30,19 @@ const DownloadButton = (props: DownloadButtonProps) => {
       hasArrow
       placement="top-start"
       label={intl.formatMessage({
-        id: "download-hover",
+        id: "save-hover",
       })}
     >
       <CollapsibleButton
         {...props}
         icon={<RiDownload2Line />}
-        onClick={actions.download}
+        onClick={actions.save}
         text={intl.formatMessage({
-          id: "download-action",
+          id: "save-action",
         })}
       />
     </Tooltip>
   );
 };
 
-export default DownloadButton;
+export default SaveButton;

--- a/src/project/SaveMenuButton.tsx
+++ b/src/project/SaveMenuButton.tsx
@@ -15,11 +15,11 @@ import {
 import { RiDownload2Line } from "react-icons/ri";
 import { FormattedMessage, useIntl } from "react-intl";
 import { zIndexAboveTerminal } from "../common/zIndex";
-import DownloadButton from "./DownloadButton";
+import SaveButton from "./SaveButton";
 import MoreMenuButton from "./MoreMenuButton";
 import { useProjectActions } from "./project-hooks";
 
-interface DownloadMenuButtonProps {
+interface SaveMenuButtonProps {
   size?: ThemeTypings["components"]["Button"]["sizes"];
 }
 
@@ -27,27 +27,27 @@ interface DownloadMenuButtonProps {
  * The device connection area.
  *
  * It shows the current connection status and allows the user to
- * flash (if WebUSB is supported) or otherwise just download a HEX.
+ * flash (if WebUSB is supported) or otherwise just save a HEX.
  */
-const DownloadMenuButton = ({ size }: DownloadMenuButtonProps) => {
+const SaveMenuButton = ({ size }: SaveMenuButtonProps) => {
   const intl = useIntl();
   const actions = useProjectActions();
   return (
     <HStack>
       <Menu>
         <ButtonGroup isAttached>
-          <DownloadButton mode="button" size={size} borderRight="1px" />
+          <SaveButton mode="button" size={size} borderRight="1px" />
           <MoreMenuButton
-            aria-label={intl.formatMessage({ id: "more-download-options" })}
+            aria-label={intl.formatMessage({ id: "more-save-options" })}
             size={size}
           />
           <Portal>
             <MenuList zIndex={zIndexAboveTerminal}>
               <MenuItem
                 icon={<RiDownload2Line />}
-                onClick={actions.downloadMainFile}
+                onClick={actions.saveMainFile}
               >
-                <FormattedMessage id="download-python-action" />
+                <FormattedMessage id="save-python-action" />
               </MenuItem>
             </MenuList>
           </Portal>
@@ -57,4 +57,4 @@ const DownloadMenuButton = ({ size }: DownloadMenuButtonProps) => {
   );
 };
 
-export default DownloadMenuButton;
+export default SaveMenuButton;

--- a/src/project/project-actions.tsx
+++ b/src/project/project-actions.tsx
@@ -441,9 +441,9 @@ export class ProjectActions {
   /**
    * Trigger a browser download with a universal hex file.
    */
-  download = async () => {
+  save = async () => {
     this.logging.event({
-      type: "download",
+      type: "save",
       detail: await this.projectStats(),
     });
 
@@ -453,7 +453,7 @@ export class ProjectActions {
 
     let download: string | undefined;
     try {
-      download = await this.fs.toHexForDownload();
+      download = await this.fs.toHexForSave();
     } catch (e: any) {
       this.actionFeedback.expectedError({
         title: this.intl.formatMessage({ id: "failed-to-build-hex" }),
@@ -470,13 +470,13 @@ export class ProjectActions {
   };
 
   /**
-   * Download an individual file.
+   * Save an individual file.
    *
-   * @param filename the file to download.
+   * @param filename the file to save.
    */
-  downloadFile = async (filename: string) => {
+  saveFile = async (filename: string) => {
     this.logging.event({
-      type: "download-file",
+      type: "save-file",
     });
 
     try {
@@ -491,14 +491,14 @@ export class ProjectActions {
   };
 
   /**
-   * Download the main file renamed to match the project.
+   * Save the main file (renamed to match the project).
    *
    * There's some debate as to whether this action is more confusing than helpful
    * but leaving it around for a bit so we can try out different UI arrangements.
    */
-  downloadMainFile = async () => {
+  saveMainFile = async () => {
     this.logging.event({
-      type: "download-main-file",
+      type: "save-main-file",
     });
 
     if (!(await this.ensureProjectName())) {
@@ -601,7 +601,7 @@ export class ProjectActions {
     return true;
   };
 
-  editProjectName = async (isDownload: boolean = false) => {
+  editProjectName = async (isSave: boolean = false) => {
     const name = await this.dialogs.show<string | undefined>((callback) => (
       <InputDialog
         callback={callback}
@@ -609,7 +609,7 @@ export class ProjectActions {
         Body={ProjectNameQuestion}
         initialValue={this.project.name}
         actionLabel={this.intl.formatMessage({
-          id: isDownload ? "confirm-download-action" : "confirm-action",
+          id: isSave ? "confirm-save-action" : "confirm-action",
         })}
         customFocus
         validate={(name: string) =>
@@ -718,7 +718,7 @@ export class ProjectActions {
     await this.dialogs.show<void>((callback) => (
       <WebUSBDialog callback={callback} action={WebUSBErrorTrigger.Flash} />
     ));
-    this.download();
+    this.save();
   }
 
   private webusbErrorMessage(code: WebUSBErrorCode) {

--- a/src/workbench/connect-dialogs/NotFoundDialog.tsx
+++ b/src/workbench/connect-dialogs/NotFoundDialog.tsx
@@ -10,7 +10,7 @@ import { ReactNode, useCallback, useState } from "react";
 import { RiDownload2Line, RiExternalLinkLine } from "react-icons/ri";
 import { FormattedMessage } from "react-intl";
 import { GenericDialog } from "../../common/GenericDialog";
-import DownloadButton from "../../project/DownloadButton";
+import SaveButton from "../../project/SaveButton";
 import { ConnectErrorChoice } from "./FirmwareDialog";
 import notFound from "./not-found.svg";
 
@@ -24,7 +24,7 @@ export const NotFoundDialog = ({ callback }: NotFoundDialogProps) => {
     setReturnFocus(false);
     callback(ConnectErrorChoice.TRY_AGAIN);
   }, [callback, setReturnFocus]);
-  const onDownload = useCallback(() => {
+  const onSave = useCallback(() => {
     setReturnFocus(false);
     callback(ConnectErrorChoice.CANCEL);
   }, [callback, setReturnFocus]);
@@ -32,9 +32,7 @@ export const NotFoundDialog = ({ callback }: NotFoundDialogProps) => {
     <GenericDialog
       returnFocusOnClose={returnFocus}
       onClose={() => callback(ConnectErrorChoice.CANCEL)}
-      body={
-        <NotFoundDialogBody onDownload={onDownload} onTryAgain={onTryAgain} />
-      }
+      body={<NotFoundDialogBody onSave={onSave} onTryAgain={onTryAgain} />}
       footer={
         <NotFoundDialogFooter
           onTryAgain={onTryAgain}
@@ -47,12 +45,12 @@ export const NotFoundDialog = ({ callback }: NotFoundDialogProps) => {
 };
 
 interface ConnectNotFoundDialogProps {
-  onDownload: () => void;
+  onSave: () => void;
   onTryAgain: () => void;
 }
 
 const NotFoundDialogBody = ({
-  onDownload,
+  onSave,
   onTryAgain,
 }: ConnectNotFoundDialogProps) => {
   const handleReviewDevice = useCallback(
@@ -152,10 +150,10 @@ const NotFoundDialogBody = ({
       >
         <Icon as={RiDownload2Line} color="brand.500" h={6} w={6} mr={5} />
         <Text fontWeight="semibold" mr="auto">
-          <FormattedMessage id="not-found-download-message" />
+          <FormattedMessage id="not-found-save-message" />
         </Text>
-        <Box onClick={onDownload}>
-          <DownloadButton mode="button" />
+        <Box onClick={onSave}>
+          <SaveButton mode="button" />
         </Box>
       </Flex>
     </VStack>


### PR DESCRIPTION
- We want ‘Send to micro:bit’ to be the preferred route for flashing -
  if you can’t use WebUSB it downloads and gives you instructions anyway
  and if it fails then the download route is now a clear alternative

- We know that some people aren’t sure how to save to backup their work
  and don’t realise that download does the same thing. Save is the label
  more folk are familiar with.

- Long term if we have other ways to save (say cloud storage) then Save
  is the better label to hang these off.