### PR TITLE
Hide drag image in DOM.

### DIFF
--- a/src/documentation/documentation-hooks.tsx
+++ b/src/documentation/documentation-hooks.tsx
@@ -134,7 +134,6 @@ export const useCodeDragImage = (): RefObject<HTMLImageElement | undefined> => {
       img.style.top = "0";
       img.style.zIndex = "-1";
       // Seems to need to be in the DOM for Safari.
-      // Our layout means this will be offscreen.
       document.body.appendChild(img);
     }
     ref.current = img;

--- a/src/documentation/documentation-hooks.tsx
+++ b/src/documentation/documentation-hooks.tsx
@@ -130,6 +130,9 @@ export const useCodeDragImage = (): RefObject<HTMLImageElement | undefined> => {
       img.id = id;
       img.alt = "";
       img.src = dragImage;
+      img.style.position = "absolute";
+      img.style.top = "0";
+      img.style.zIndex = "-1";
       // Seems to need to be in the DOM for Safari.
       // Our layout means this will be offscreen.
       document.body.appendChild(img);


### PR DESCRIPTION
Drag image is needed in the DOM for Safari. Style updates here keep this hidden from view. 