### PR TITLE
Add post-save dialog and update flow.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -515,6 +515,26 @@
     "defaultMessage": "Permanently delete {filename}?",
     "description": "Confirmation question to permanently delete file"
   },
+  "post-save-message-files": {
+    "defaultMessage": "This contains all files in this project (including any additional files, e.g. to run accessories, listed in the Project section).",
+    "description": "Message in dialog shown after the user saves the project as a hex file."
+  },
+  "post-save-message-one": {
+    "defaultMessage": "You will find your hex file in your <strong>Downloads</strong> folder.",
+    "description": "Message in dialog shown after the user saves the project as a hex file."
+  },
+  "post-save-message-two": {
+    "defaultMessage": "You can move it to another folder for storage and use <strong>Open</strong> to continue editing later.",
+    "description": "Message in dialog shown after the user saves the project as a hex file."
+  },
+  "post-save-title": {
+    "defaultMessage": "Project saved",
+    "description": "Title of dialog shown after the user saves the project as a hex file."
+  },
+  "post-save-transfer-hex": {
+    "defaultMessage": "To transfer your hex file to run on your micro:bit <link>follow these steps</link>.",
+    "description": "Message in dialog shown after the user saves the project as a hex file."
+  },
   "project-actions": {
     "defaultMessage": "Project actions",
     "description": "Aria label for the bar with project actions"

--- a/lang/en.json
+++ b/lang/en.json
@@ -427,6 +427,14 @@
     "defaultMessage": "More save options",
     "description": "Aria label for the additional actions menu to the right of the Save button"
   },
+  "multiple-files-message": {
+    "defaultMessage": "This project contains multiple Python files and only 'main.py' has been downloaded. To download other Python files, use the 'Project' tab.",
+    "description": "Message in dialog shown when multiple Python files are available for download"
+  },
+  "multiple-files-title": {
+    "defaultMessage": "Multiple Python files",
+    "description": "Title of dialog shown when multiple Python files are available for download"
+  },
   "name-project": {
     "defaultMessage": "Name your project",
     "description": "Name your project header"

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -514,6 +514,26 @@
     "defaultMessage": "Supprimer {filename} définitivement ?",
     "description": "Confirmation question to permanently delete file"
   },
+  "post-save-message-files": {
+    "defaultMessage": "This contains all files in this project (including any additional files, e.g. to run accessories, listed in the Project section).",
+    "description": "Message in dialog shown after the user saves the project as a hex file."
+  },
+  "post-save-message-one": {
+    "defaultMessage": "You will find your hex file in your <strong>Downloads</strong> folder.",
+    "description": "Message in dialog shown after the user saves the project as a hex file."
+  },
+  "post-save-message-two": {
+    "defaultMessage": "You can move it to another folder for storage and use <strong>Open</strong> to continue editing later.",
+    "description": "Message in dialog shown after the user saves the project as a hex file."
+  },
+  "post-save-title": {
+    "defaultMessage": "Project saved",
+    "description": "Title of dialog shown after the user saves the project as a hex file."
+  },
+  "post-save-transfer-hex": {
+    "defaultMessage": "To transfer your hex file to run on your micro:bit <link>follow these steps</link>.",
+    "description": "Message in dialog shown after the user saves the project as a hex file."
+  },
   "project-actions": {
     "defaultMessage": "Actions du projet",
     "description": "Aria label for the bar with project actions"

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -426,6 +426,14 @@
     "defaultMessage": "More save options",
     "description": "Aria label for the additional actions menu to the right of the Save button"
   },
+  "multiple-files-message": {
+    "defaultMessage": "This project contains multiple Python files and only 'main.py' has been downloaded. To download other Python files, use the 'Project' tab.",
+    "description": "Message in dialog shown when multiple Python files are available for download"
+  },
+  "multiple-files-title": {
+    "defaultMessage": "Multiple Python files",
+    "description": "Title of dialog shown when multiple Python files are available for download"
+  },
   "name-project": {
     "defaultMessage": "Donnez un nom à votre projet",
     "description": "Name your project header"

--- a/lang/lol.json
+++ b/lang/lol.json
@@ -514,6 +514,26 @@
     "defaultMessage": "Перманентлу делете {filename}?",
     "description": "Confirmation question to permanently delete file"
   },
+  "post-save-message-files": {
+    "defaultMessage": "This contains all files in this project (including any additional files, e.g. to run accessories, listed in the Project section).",
+    "description": "Message in dialog shown after the user saves the project as a hex file."
+  },
+  "post-save-message-one": {
+    "defaultMessage": "You will find your hex file in your <strong>Downloads</strong> folder.",
+    "description": "Message in dialog shown after the user saves the project as a hex file."
+  },
+  "post-save-message-two": {
+    "defaultMessage": "You can move it to another folder for storage and use <strong>Open</strong> to continue editing later.",
+    "description": "Message in dialog shown after the user saves the project as a hex file."
+  },
+  "post-save-title": {
+    "defaultMessage": "Project saved",
+    "description": "Title of dialog shown after the user saves the project as a hex file."
+  },
+  "post-save-transfer-hex": {
+    "defaultMessage": "To transfer your hex file to run on your micro:bit <link>follow these steps</link>.",
+    "description": "Message in dialog shown after the user saves the project as a hex file."
+  },
   "project-actions": {
     "defaultMessage": "Проджест астіонс",
     "description": "Aria label for the bar with project actions"

--- a/lang/lol.json
+++ b/lang/lol.json
@@ -426,6 +426,14 @@
     "defaultMessage": "More save options",
     "description": "Aria label for the additional actions menu to the right of the Save button"
   },
+  "multiple-files-message": {
+    "defaultMessage": "This project contains multiple Python files and only 'main.py' has been downloaded. To download other Python files, use the 'Project' tab.",
+    "description": "Message in dialog shown when multiple Python files are available for download"
+  },
+  "multiple-files-title": {
+    "defaultMessage": "Multiple Python files",
+    "description": "Title of dialog shown when multiple Python files are available for download"
+  },
   "name-project": {
     "defaultMessage": "Наме уоюр проджест",
     "description": "Name your project header"

--- a/src/common/MultipleFilesDialog.tsx
+++ b/src/common/MultipleFilesDialog.tsx
@@ -53,7 +53,7 @@ const MultipleFilesDialogFooter = ({
 }: MultipleFilesDialogFooterProps) => {
   return (
     <HStack spacing={2.5}>
-      <Button onClick={onClose} size="lg">
+      <Button onClick={onClose} size="md">
         <FormattedMessage id="close-action" />
       </Button>
     </HStack>

--- a/src/common/MultipleFilesDialog.tsx
+++ b/src/common/MultipleFilesDialog.tsx
@@ -1,0 +1,63 @@
+/**
+ * (c) 2022, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { Button } from "@chakra-ui/button";
+import { HStack, Text, VStack } from "@chakra-ui/react";
+import { FormattedMessage } from "react-intl";
+import { GenericDialog } from "../common/GenericDialog";
+
+interface MultipleFilesDialogProps {
+  callback: () => void;
+}
+
+export const MultipleFilesDialog = ({ callback }: MultipleFilesDialogProps) => {
+  return (
+    <GenericDialog
+      onClose={() => callback()}
+      body={<MultipleFilesDialogBody />}
+      footer={<MultipleFilesDialogFooter onClose={() => callback()} />}
+      size="xl"
+    />
+  );
+};
+
+const MultipleFilesDialogBody = () => {
+  return (
+    <VStack
+      width="auto"
+      ml="auto"
+      mr="auto"
+      p={5}
+      pb={0}
+      spacing={5}
+      alignItems="flex-start"
+    >
+      <Text as="h2" fontSize="xl" fontWeight="semibold">
+        <FormattedMessage id="multiple-files-title" />
+      </Text>
+      <Text>
+        <FormattedMessage id="multiple-files-message" />
+      </Text>
+    </VStack>
+  );
+};
+
+interface MultipleFilesDialogFooterProps {
+  onClose: () => void;
+}
+
+const MultipleFilesDialogFooter = ({
+  onClose,
+}: MultipleFilesDialogFooterProps) => {
+  return (
+    <HStack spacing={2.5}>
+      <Button onClick={onClose} size="lg">
+        <FormattedMessage id="close-action" />
+      </Button>
+    </HStack>
+  );
+};
+
+export default MultipleFilesDialog;

--- a/src/common/PostSaveDialog.tsx
+++ b/src/common/PostSaveDialog.tsx
@@ -1,0 +1,163 @@
+/**
+ * (c) 2022, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { Button } from "@chakra-ui/button";
+import { HStack, Link, Text, VStack } from "@chakra-ui/react";
+import { ReactNode, useCallback, useEffect, useState } from "react";
+import { FormattedMessage } from "react-intl";
+import { GenericDialog } from "../common/GenericDialog";
+import { useFileSystem } from "../fs/fs-hooks";
+
+export const enum PostSaveChoice {
+  ShowTransferHexHelp,
+  CloseDontShowAgain,
+  Close,
+}
+
+interface PostSaveDialogProps {
+  callback: (value: PostSaveChoice) => void;
+  dialogNormallyHidden: boolean;
+}
+
+export const PostSaveDialog = ({
+  callback,
+  dialogNormallyHidden,
+}: PostSaveDialogProps) => {
+  const [returnFocus, setReturnFocus] = useState<boolean>(true);
+  const onShowTransferHexHelp = useCallback(() => {
+    setReturnFocus(false);
+    callback(PostSaveChoice.ShowTransferHexHelp);
+  }, [callback, setReturnFocus]);
+  return (
+    <GenericDialog
+      returnFocusOnClose={returnFocus}
+      onClose={() => callback(PostSaveChoice.Close)}
+      body={
+        <PostSaveDialogBody onShowTransferHexHelp={onShowTransferHexHelp} />
+      }
+      footer={
+        <PostSaveDialogFooter
+          dialogNormallyHidden={dialogNormallyHidden}
+          onClose={() => callback(PostSaveChoice.Close)}
+          onCloseDontShowAgain={() =>
+            callback(PostSaveChoice.CloseDontShowAgain)
+          }
+        />
+      }
+      size="xl"
+    />
+  );
+};
+
+interface PostSaveDialogBodyProps {
+  onShowTransferHexHelp: () => void;
+}
+
+const PostSaveDialogBody = ({
+  onShowTransferHexHelp,
+}: PostSaveDialogBodyProps) => {
+  const fs = useFileSystem();
+  const [multipleFiles, setMultipleFiles] = useState<boolean>(false);
+  useEffect(() => {
+    const areMultipleFiles = async () => {
+      const result = (await fs.statistics()).files > 1;
+      setMultipleFiles(result);
+    };
+    areMultipleFiles();
+  }, [fs, setMultipleFiles]);
+  const handleShowTransferHexHelp = useCallback(
+    (e: React.MouseEvent<HTMLElement>) => {
+      e.preventDefault();
+      onShowTransferHexHelp();
+    },
+    [onShowTransferHexHelp]
+  );
+  return (
+    <VStack
+      width="auto"
+      ml="auto"
+      mr="auto"
+      p={5}
+      pb={0}
+      spacing={5}
+      alignItems="flex-start"
+    >
+      <Text as="h2" fontSize="xl" fontWeight="semibold">
+        <FormattedMessage id="post-save-title" />
+      </Text>
+      <Text>
+        <FormattedMessage
+          id="post-save-message-one"
+          values={{
+            strong: (chunks: ReactNode) => (
+              <Text as="span" fontWeight="semibold">
+                {chunks}
+              </Text>
+            ),
+          }}
+        />
+        {multipleFiles && <FormattedMessage id="post-save-message-files" />}
+        <FormattedMessage
+          id="post-save-message-two"
+          values={{
+            strong: (chunks: ReactNode) => (
+              <Text as="span" fontWeight="semibold">
+                {chunks}
+              </Text>
+            ),
+          }}
+        />
+      </Text>
+      <Text>
+        <FormattedMessage
+          id="post-save-transfer-hex"
+          values={{
+            link: (chunks: ReactNode) => (
+              <Link
+                color="brand.500"
+                onClick={handleShowTransferHexHelp}
+                href=""
+              >
+                {chunks}
+              </Link>
+            ),
+          }}
+        />
+      </Text>
+    </VStack>
+  );
+};
+
+interface PostSaveDialogFooterProps {
+  dialogNormallyHidden: boolean;
+  onClose: () => void;
+  onCloseDontShowAgain: () => void;
+}
+
+const PostSaveDialogFooter = ({
+  dialogNormallyHidden,
+  onClose,
+  onCloseDontShowAgain,
+}: PostSaveDialogFooterProps) => {
+  return (
+    <HStack spacing={2.5} width={dialogNormallyHidden ? "auto" : "100%"}>
+      {!dialogNormallyHidden && (
+        <Link
+          onClick={onCloseDontShowAgain}
+          as="button"
+          color="brand.500"
+          mr="auto"
+        >
+          <FormattedMessage id="dont-show-again" />
+        </Link>
+      )}
+      <Button onClick={onClose} variant="solid" size="md">
+        <FormattedMessage id="close-action" />
+      </Button>
+    </HStack>
+  );
+};
+
+export default PostSaveDialog;

--- a/src/common/PostSaveDialog.tsx
+++ b/src/common/PostSaveDialog.tsx
@@ -25,14 +25,11 @@ export const PostSaveDialog = ({
   callback,
   dialogNormallyHidden,
 }: PostSaveDialogProps) => {
-  const [returnFocus, setReturnFocus] = useState<boolean>(true);
   const onShowTransferHexHelp = useCallback(() => {
-    setReturnFocus(false);
     callback(PostSaveChoice.ShowTransferHexHelp);
-  }, [callback, setReturnFocus]);
+  }, [callback]);
   return (
     <GenericDialog
-      returnFocusOnClose={returnFocus}
       onClose={() => callback(PostSaveChoice.Close)}
       body={
         <PostSaveDialogBody onShowTransferHexHelp={onShowTransferHexHelp} />

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -851,6 +851,18 @@
       "value": "More save options"
     }
   ],
+  "multiple-files-message": [
+    {
+      "type": 0,
+      "value": "This project contains multiple Python files and only 'main.py' has been downloaded. To download other Python files, use the 'Project' tab."
+    }
+  ],
+  "multiple-files-title": [
+    {
+      "type": 0,
+      "value": "Multiple Python files"
+    }
+  ],
   "name-project": [
     {
       "type": 0,

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1079,6 +1079,78 @@
       "value": "?"
     }
   ],
+  "post-save-message-files": [
+    {
+      "type": 0,
+      "value": "This contains all files in this project (including any additional files, e.g. to run accessories, listed in the Project section)."
+    }
+  ],
+  "post-save-message-one": [
+    {
+      "type": 0,
+      "value": "You will find your hex file in your "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "Downloads"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " folder."
+    }
+  ],
+  "post-save-message-two": [
+    {
+      "type": 0,
+      "value": "You can move it to another folder for storage and use "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "Open"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " to continue editing later."
+    }
+  ],
+  "post-save-title": [
+    {
+      "type": 0,
+      "value": "Project saved"
+    }
+  ],
+  "post-save-transfer-hex": [
+    {
+      "type": 0,
+      "value": "To transfer your hex file to run on your micro:bit "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "follow these steps"
+        }
+      ],
+      "type": 8,
+      "value": "link"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
   "project-actions": [
     {
       "type": 0,

--- a/src/messages/fr.json
+++ b/src/messages/fr.json
@@ -1027,6 +1027,78 @@
       "value": " définitivement ?"
     }
   ],
+  "post-save-message-files": [
+    {
+      "type": 0,
+      "value": "This contains all files in this project (including any additional files, e.g. to run accessories, listed in the Project section)."
+    }
+  ],
+  "post-save-message-one": [
+    {
+      "type": 0,
+      "value": "You will find your hex file in your "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "Downloads"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " folder."
+    }
+  ],
+  "post-save-message-two": [
+    {
+      "type": 0,
+      "value": "You can move it to another folder for storage and use "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "Open"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " to continue editing later."
+    }
+  ],
+  "post-save-title": [
+    {
+      "type": 0,
+      "value": "Project saved"
+    }
+  ],
+  "post-save-transfer-hex": [
+    {
+      "type": 0,
+      "value": "To transfer your hex file to run on your micro:bit "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "follow these steps"
+        }
+      ],
+      "type": 8,
+      "value": "link"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
   "project-actions": [
     {
       "type": 0,

--- a/src/messages/fr.json
+++ b/src/messages/fr.json
@@ -841,6 +841,18 @@
       "value": "More save options"
     }
   ],
+  "multiple-files-message": [
+    {
+      "type": 0,
+      "value": "This project contains multiple Python files and only 'main.py' has been downloaded. To download other Python files, use the 'Project' tab."
+    }
+  ],
+  "multiple-files-title": [
+    {
+      "type": 0,
+      "value": "Multiple Python files"
+    }
+  ],
   "name-project": [
     {
       "type": 0,

--- a/src/messages/lol.json
+++ b/src/messages/lol.json
@@ -1027,6 +1027,78 @@
       "value": "?"
     }
   ],
+  "post-save-message-files": [
+    {
+      "type": 0,
+      "value": "This contains all files in this project (including any additional files, e.g. to run accessories, listed in the Project section)."
+    }
+  ],
+  "post-save-message-one": [
+    {
+      "type": 0,
+      "value": "You will find your hex file in your "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "Downloads"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " folder."
+    }
+  ],
+  "post-save-message-two": [
+    {
+      "type": 0,
+      "value": "You can move it to another folder for storage and use "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "Open"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " to continue editing later."
+    }
+  ],
+  "post-save-title": [
+    {
+      "type": 0,
+      "value": "Project saved"
+    }
+  ],
+  "post-save-transfer-hex": [
+    {
+      "type": 0,
+      "value": "To transfer your hex file to run on your micro:bit "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "follow these steps"
+        }
+      ],
+      "type": 8,
+      "value": "link"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
   "project-actions": [
     {
       "type": 0,

--- a/src/messages/lol.json
+++ b/src/messages/lol.json
@@ -841,6 +841,18 @@
       "value": "More save options"
     }
   ],
+  "multiple-files-message": [
+    {
+      "type": 0,
+      "value": "This project contains multiple Python files and only 'main.py' has been downloaded. To download other Python files, use the 'Project' tab."
+    }
+  ],
+  "multiple-files-title": [
+    {
+      "type": 0,
+      "value": "Multiple Python files"
+    }
+  ],
   "name-project": [
     {
       "type": 0,

--- a/src/project/SaveButton.tsx
+++ b/src/project/SaveButton.tsx
@@ -36,7 +36,7 @@ const SaveButton = (props: SaveButtonProps) => {
       <CollapsibleButton
         {...props}
         icon={<RiDownload2Line />}
-        onClick={actions.save}
+        onClick={() => actions.save()}
         text={intl.formatMessage({
           id: "save-action",
         })}

--- a/src/project/project-actions.tsx
+++ b/src/project/project-actions.tsx
@@ -515,7 +515,7 @@ export class ProjectActions {
       const blob = new Blob([content.data], {
         type: "application/octet-stream",
       });
-      const filename = `${this.project.name}.py`;
+      const filename = `${this.project.name}-${MAIN_FILE}`;
       saveAs(blob, filename);
     } catch (e) {
       this.actionFeedback.unexpectedError(e);

--- a/src/project/project-actions.tsx
+++ b/src/project/project-actions.tsx
@@ -10,6 +10,7 @@ import { ReactNode } from "react";
 import { FormattedMessage, IntlShape } from "react-intl";
 import { ConfirmDialog } from "../common/ConfirmDialog";
 import { InputDialog, InputDialogBody } from "../common/InputDialog";
+import MultipleFilesDialog from "../common/MultipleFilesDialog";
 import { ActionFeedback } from "../common/use-action-feedback";
 import { Dialogs } from "../common/use-dialogs";
 import {
@@ -517,6 +518,11 @@ export class ProjectActions {
       });
       const filename = `${this.project.name}-${MAIN_FILE}`;
       saveAs(blob, filename);
+      if ((await this.fs.statistics()).files > 1) {
+        await this.dialogs.show<void>((callback) => (
+          <MultipleFilesDialog callback={callback} />
+        ));
+      }
     } catch (e) {
       this.actionFeedback.unexpectedError(e);
     }

--- a/src/project/project-actions.tsx
+++ b/src/project/project-actions.tsx
@@ -32,6 +32,7 @@ import {
 import { PythonProject } from "../fs/initial-project";
 import { LanguageServerClient } from "../language-server/client";
 import { Logging } from "../logging/logging";
+import { SessionSettings } from "../settings/session-settings";
 import { Settings } from "../settings/settings";
 import ConnectDialog, {
   ConnectHelpChoice,
@@ -95,6 +96,10 @@ export class ProjectActions {
     private settings: {
       values: Settings;
       setValues: (v: Settings) => void;
+    },
+    private sessionSettings: {
+      values: SessionSettings;
+      setValues: (v: SessionSettings) => void;
     },
     private intl: IntlShape,
     private logging: Logging,
@@ -715,9 +720,15 @@ export class ProjectActions {
   }
 
   private async webusbNotSupportedError(): Promise<void> {
-    await this.dialogs.show<void>((callback) => (
-      <WebUSBDialog callback={callback} action={WebUSBErrorTrigger.Flash} />
-    ));
+    if (this.sessionSettings.values.showWebUsbNotSupported) {
+      await this.dialogs.show<void>((callback) => (
+        <WebUSBDialog callback={callback} action={WebUSBErrorTrigger.Flash} />
+      ));
+      this.sessionSettings.setValues({
+        ...this.sessionSettings.values,
+        showWebUsbNotSupported: false,
+      });
+    }
     this.save();
   }
 

--- a/src/project/project-actions.tsx
+++ b/src/project/project-actions.tsx
@@ -46,9 +46,7 @@ import NotFoundDialog from "../workbench/connect-dialogs/NotFoundDialog";
 import TransferHexDialog, {
   TransferHexChoice,
 } from "../workbench/connect-dialogs/TransferHexDialog";
-import WebUSBDialog, {
-  WebUSBErrorTrigger,
-} from "../workbench/connect-dialogs/WebUSBDialog";
+import WebUSBDialog from "../workbench/connect-dialogs/WebUSBDialog";
 import { WorkbenchSelection } from "../workbench/use-selection";
 import {
   ClassifiedFileInput,
@@ -733,7 +731,7 @@ export class ProjectActions {
   private async webusbNotSupportedError(): Promise<void> {
     if (this.sessionSettings.values.showWebUsbNotSupported) {
       await this.dialogs.show<void>((callback) => (
-        <WebUSBDialog callback={callback} action={WebUSBErrorTrigger.Flash} />
+        <WebUSBDialog callback={callback} />
       ));
       this.sessionSettings.setValues({
         ...this.sessionSettings.values,

--- a/src/project/project-hooks.tsx
+++ b/src/project/project-hooks.tsx
@@ -13,6 +13,7 @@ import { EVENT_PROJECT_UPDATED, Project, VersionAction } from "../fs/fs";
 import { useFileSystem } from "../fs/fs-hooks";
 import { useLanguageServerClient } from "../language-server/language-server-hooks";
 import { useLogging } from "../logging/logging-hooks";
+import { useSessionSettings } from "../settings/session-settings";
 import { useSettings } from "../settings/settings";
 import { useSelection } from "../workbench/use-selection";
 import { defaultedProject, ProjectActions } from "./project-actions";
@@ -30,6 +31,7 @@ export const useProjectActions = (): ProjectActions => {
   const intl = useIntl();
   const client = useLanguageServerClient();
   const [settings, setSettings] = useSettings();
+  const [sessionSettings, setSessionSettings] = useSessionSettings();
   const actions = useMemo<ProjectActions>(
     () =>
       new ProjectActions(
@@ -39,6 +41,7 @@ export const useProjectActions = (): ProjectActions => {
         dialogs,
         setSelection,
         { values: settings, setValues: setSettings },
+        { values: sessionSettings, setValues: setSessionSettings },
         intl,
         logging,
         client
@@ -54,6 +57,8 @@ export const useProjectActions = (): ProjectActions => {
       client,
       settings,
       setSettings,
+      sessionSettings,
+      setSessionSettings,
     ]
   );
   return actions;

--- a/src/settings/session-settings.tsx
+++ b/src/settings/session-settings.tsx
@@ -8,10 +8,12 @@ import { useStorage } from "../common/use-storage";
 
 export interface SessionSettings {
   dragDropSuccess: boolean;
+  showWebUsbNotSupported: boolean;
 }
 
 export const defaultSessionSettings: SessionSettings = {
   dragDropSuccess: false,
+  showWebUsbNotSupported: true,
 };
 
 export type SessionSettingsContextValue = [

--- a/src/settings/settings.tsx
+++ b/src/settings/settings.tsx
@@ -61,6 +61,7 @@ export const defaultSettings: Settings = {
   parameterHelp: "automatic",
   showConnectHelp: true,
   showTransferHexHelp: true,
+  showPostSaveHelpSetting: true,
 };
 
 export const isValidSettingsObject = (value: unknown): value is Settings => {
@@ -99,6 +100,7 @@ export interface Settings {
   parameterHelp: ParameterHelpOption;
   showConnectHelp: boolean;
   showTransferHexHelp: boolean;
+  showPostSaveHelpSetting: boolean;
 }
 
 type SettingsContextValue = [Settings, (settings: Settings) => void];

--- a/src/workbench/connect-dialogs/WebUSBDialog.tsx
+++ b/src/workbench/connect-dialogs/WebUSBDialog.tsx
@@ -9,35 +9,25 @@ import { useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 import { GenericDialog } from "../../common/GenericDialog";
 
-export const enum WebUSBErrorTrigger {
-  Connect,
-  Flash,
-}
-
 interface WebUSBDialogProps {
   callback: () => void;
-  action: WebUSBErrorTrigger;
 }
 
-export const WebUSBDialog = ({ callback, action }: WebUSBDialogProps) => {
+export const WebUSBDialog = ({ callback }: WebUSBDialogProps) => {
   const handleClose = useCallback(() => {
     callback();
   }, [callback]);
   return (
     <GenericDialog
       onClose={handleClose}
-      body={<WebUSBDialogBody action={action} />}
+      body={<WebUSBDialogBody />}
       footer={<WebUSBDialogFooter onCancel={handleClose} />}
       size="3xl"
     />
   );
 };
 
-interface WebUSBDialogBodyProps {
-  action: WebUSBErrorTrigger;
-}
-
-const WebUSBDialogBody = ({ action }: WebUSBDialogBodyProps) => {
+const WebUSBDialogBody = () => {
   return (
     <VStack
       width="auto"


### PR DESCRIPTION
If WebUSB is supported, saving a hex will trigger a post-save dialog, providing information about the hex downloaded. It also offers a link to the transfer hex help dialog.

On saving the main script from the additional options on the save button, the main script is downloaded, and is now suffixed with "main.py". If there are multiple files in the project, a dialog is shown to warn the user that only main.py has been saved, and advises on how to download other the Python files in the project.

On flashing/connecting when WebUSB is not supported, the WebUSB dialog is shown once per session, followed by the transfer hex help dialog, there after, only the transfer hex help dialog is shown.