### PR TITLE
Hide sync status for simulator serial.

### DIFF
--- a/src/serial/SerialArea.tsx
+++ b/src/serial/SerialArea.tsx
@@ -14,6 +14,7 @@ import XTerm from "./XTerm";
 interface SerialAreaProps extends BoxProps {
   compact?: boolean;
   onSizeChange: (size: "compact" | "open") => void;
+  showSyncStatus: boolean;
 }
 
 /**
@@ -22,7 +23,12 @@ interface SerialAreaProps extends BoxProps {
  * This has a compact and expanded form and coordinates its
  * size with the workspace layout via compact/onSizeChange.
  */
-const SerialArea = ({ compact, onSizeChange, ...props }: SerialAreaProps) => {
+const SerialArea = ({
+  compact,
+  onSizeChange,
+  showSyncStatus,
+  ...props
+}: SerialAreaProps) => {
   const status = useConnectionStatus();
   const connected = status === ConnectionStatus.CONNECTED;
   return (
@@ -45,6 +51,7 @@ const SerialArea = ({ compact, onSizeChange, ...props }: SerialAreaProps) => {
               height={12}
               compact={compact}
               onSizeChange={onSizeChange}
+              showSyncStatus={showSyncStatus}
             />
             <XTerm
               visibility={compact ? "hidden" : undefined}

--- a/src/serial/SerialBar.tsx
+++ b/src/serial/SerialBar.tsx
@@ -27,6 +27,7 @@ import SerialMenu from "./SerialMenu";
 interface SerialBarProps extends BoxProps {
   compact?: boolean;
   onSizeChange: (size: "compact" | "open") => void;
+  showSyncStatus: boolean;
 }
 
 /**
@@ -36,6 +37,7 @@ const SerialBar = ({
   compact,
   onSizeChange,
   background,
+  showSyncStatus,
   ...props
 }: SerialBarProps) => {
   const logging = useLogging();
@@ -71,6 +73,7 @@ const SerialBar = ({
           compact={compact}
           traceback={traceback}
           overflow="hidden"
+          showSyncStatus={showSyncStatus}
         />
 
         <HStack>

--- a/src/serial/SerialIndicators.tsx
+++ b/src/serial/SerialIndicators.tsx
@@ -17,6 +17,7 @@ import MaybeTracebackLink from "./MaybeTracebackLink";
 interface SerialIndicatorsProps extends BoxProps {
   compact?: boolean;
   traceback?: Traceback | undefined;
+  showSyncStatus: boolean;
 }
 
 const syncMessages = {
@@ -36,10 +37,14 @@ const syncMessages = {
 const SerialIndicators = ({
   compact,
   traceback,
+  showSyncStatus,
   ...props
 }: SerialIndicatorsProps) => {
   const syncStatus = useSyncStatus();
   const syncMessage = syncMessages[syncStatus];
+  const displaySyncMessage =
+    showSyncStatus &&
+    (!traceback || (traceback && syncStatus === SyncStatus.OUT_OF_SYNC));
   return (
     <HStack {...props}>
       <Icon m={1} as={RiTerminalBoxLine} fill="white" boxSize={5} />
@@ -52,8 +57,7 @@ const SerialIndicators = ({
             </Text>
           </>
         )}
-        {(!traceback ||
-          (traceback && syncStatus === SyncStatus.OUT_OF_SYNC)) && (
+        {displaySyncMessage && (
           <Text color="white" display="inline-flex" alignItems="center">
             <FormattedMessage id={syncMessage?.message} />
             {syncMessage?.icon && (

--- a/src/simulator/SimulatorActionBar.tsx
+++ b/src/simulator/SimulatorActionBar.tsx
@@ -68,7 +68,7 @@ const SimulatorActionBar = (props: SimulatorActionBarProps) => {
         onClick={device.reset}
         icon={<RiRefreshLine />}
         aria-label="Reset"
-        disabled={syncStatus === SyncStatus.OUT_OF_SYNC}
+        disabled={simState === SimState.STOPPED}
       />
     </HStack>
   );

--- a/src/simulator/SimulatorActionBar.tsx
+++ b/src/simulator/SimulatorActionBar.tsx
@@ -68,6 +68,7 @@ const SimulatorActionBar = (props: SimulatorActionBarProps) => {
         onClick={device.reset}
         icon={<RiRefreshLine />}
         aria-label="Reset"
+        disabled={syncStatus === SyncStatus.OUT_OF_SYNC}
       />
     </HStack>
   );

--- a/src/simulator/SimulatorSplitView.tsx
+++ b/src/simulator/SimulatorSplitView.tsx
@@ -44,6 +44,7 @@ const SimulatorSplitView = ({ simHeight }: SimulatorSplitViewProps) => {
           aria-label={intl.formatMessage({
             id: "serial-terminal",
           })}
+          showSyncStatus={false}
         />
       </SplitViewSized>
       <SplitViewDivider />

--- a/src/workbench/Workbench.tsx
+++ b/src/workbench/Workbench.tsx
@@ -178,6 +178,7 @@ const Editor = ({
             aria-label={intl.formatMessage({
               id: "serial-terminal",
             })}
+            showSyncStatus={true}
           />
         </SplitViewSized>
       </SplitView>


### PR DESCRIPTION
The sync status is no longer required for the simulator serial bar as the simulator is obviously in sync when running and out of sync when stopped. The reset button is disabled when the simulator is stopped.