### PR TITLE
Switch focus to simulator when expanded.

### DIFF
--- a/src/common/SplitView/HideSplitViewButton.tsx
+++ b/src/common/SplitView/HideSplitViewButton.tsx
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { Box, Icon, IconButtonProps } from "@chakra-ui/react";
+import React, { ForwardedRef } from "react";
 import { RiDownloadLine } from "react-icons/ri";
 import CollapsibleButton from "../CollapsibleButton";
 import { splitViewHideButton } from "../zIndex";
@@ -15,64 +16,71 @@ interface HideSplitViewButtonProps extends IconButtonProps {
   text?: string;
 }
 
-const HideSplitViewButton = ({
-  handleClick,
-  direction,
-  splitViewShown,
-  text = "",
-  ...props
-}: HideSplitViewButtonProps) => {
-  const mode = text ? "button" : "icon";
-  let rightBorderRadius = 6;
-  let leftBorderRadius = 0;
-  let rotation = "rotate(270deg)";
-  if (
-    (direction === "expandRight" && splitViewShown) ||
-    (direction === "expandLeft" && !splitViewShown)
-  ) {
-    rightBorderRadius = 0;
-    leftBorderRadius = 6;
-    rotation = "rotate(90deg)";
-  }
-  return (
-    <Box position="relative">
-      {/* Hack to cover divider box shadow on right hand side. */}
-      {direction === "expandLeft" && splitViewShown && (
-        <Box
-          width="10px"
-          height="60px"
+const HideSplitViewButton = React.forwardRef(
+  (
+    {
+      handleClick,
+      direction,
+      splitViewShown,
+      text = "",
+      ...props
+    }: HideSplitViewButtonProps,
+    ref: ForwardedRef<HTMLButtonElement>
+  ) => {
+    const mode = text ? "button" : "icon";
+    let rightBorderRadius = 6;
+    let leftBorderRadius = 0;
+    let rotation = "rotate(270deg)";
+    if (
+      (direction === "expandRight" && splitViewShown) ||
+      (direction === "expandLeft" && !splitViewShown)
+    ) {
+      rightBorderRadius = 0;
+      leftBorderRadius = 6;
+      rotation = "rotate(90deg)";
+    }
+    return (
+      <Box position="relative">
+        {/* Hack to cover divider box shadow on right hand side. */}
+        {direction === "expandLeft" && splitViewShown && (
+          <Box
+            width="10px"
+            height="60px"
+            background="#eaecf1"
+            zIndex={5}
+            position="absolute"
+            left="-10px"
+            top="-10px"
+            pointerEvents="none"
+          />
+        )}
+        <CollapsibleButton
+          ref={ref}
+          mode={mode}
+          text={text}
+          icon={<Icon as={RiDownloadLine} transform={rotation} />}
+          fontSize="lg"
+          transition="none"
+          onClick={handleClick}
+          borderTopRightRadius={rightBorderRadius}
+          borderBottomRightRadius={rightBorderRadius}
+          borderTopLeftRadius={leftBorderRadius}
+          borderBottomLeftRadius={leftBorderRadius}
+          py={3}
+          borderColor="black"
+          size="md"
+          minW="unset"
+          width={mode === "icon" ? "20px" : "auto"}
           background="#eaecf1"
-          zIndex={5}
-          position="absolute"
-          left="-10px"
-          top="-10px"
-          pointerEvents="none"
+          color="brand.500"
+          variant="ghost"
+          zIndex={splitViewHideButton}
+          boxShadow={direction === "expandLeft" ? "md" : "none"}
+          {...props}
         />
-      )}
-      <CollapsibleButton
-        mode={mode}
-        text={text}
-        icon={<Icon as={RiDownloadLine} transform={rotation} />}
-        fontSize="lg"
-        transition="none"
-        onClick={handleClick}
-        borderTopRightRadius={rightBorderRadius}
-        borderBottomRightRadius={rightBorderRadius}
-        borderTopLeftRadius={leftBorderRadius}
-        borderBottomLeftRadius={leftBorderRadius}
-        py={3}
-        borderColor="black"
-        size="md"
-        minW="unset"
-        width={mode === "icon" ? "20px" : "auto"}
-        background="#eaecf1"
-        color="brand.500"
-        variant="ghost"
-        zIndex={splitViewHideButton}
-        boxShadow={direction === "expandLeft" ? "md" : "none"}
-        {...props}
-      />
-    </Box>
-  );
-};
+      </Box>
+    );
+  }
+);
+
 export default HideSplitViewButton;

--- a/src/editor/EditorArea.tsx
+++ b/src/editor/EditorArea.tsx
@@ -14,7 +14,7 @@ import ZoomControls from "../editor/ZoomControls";
 import UndoRedoControls from "./UndoRedoControls";
 import { widthXl } from "../common/media-queries";
 import HideSplitViewButton from "../common/SplitView/HideSplitViewButton";
-import { useCallback } from "react";
+import React, { ForwardedRef, useCallback } from "react";
 import { flags } from "../flags";
 
 interface EditorAreaProps extends BoxProps {
@@ -28,84 +28,89 @@ interface EditorAreaProps extends BoxProps {
  * Wrapper for the editor that integrates it with the app settings
  * and wires it to the currently open file.
  */
-const EditorArea = ({
-  selection,
-  onSelectedFileChanged,
-  simulatorShown,
-  setSimulatorShown,
-  ...props
-}: EditorAreaProps) => {
-  const intl = useIntl();
-  const [isWideScreen] = useMediaQuery(widthXl);
-  const showSimulator = useCallback(() => {
-    setSimulatorShown(true);
-  }, [setSimulatorShown]);
-  return (
-    <Flex
-      height="100%"
-      flexDirection="column"
-      {...props}
-      backgroundColor="gray.10"
-    >
+const EditorArea = React.forwardRef(
+  (
+    {
+      selection,
+      onSelectedFileChanged,
+      simulatorShown,
+      setSimulatorShown,
+      ...props
+    }: EditorAreaProps,
+    simulatorButtonRef: ForwardedRef<HTMLButtonElement>
+  ) => {
+    const intl = useIntl();
+    const [isWideScreen] = useMediaQuery(widthXl);
+    const showSimulator = useCallback(() => {
+      setSimulatorShown(true);
+    }, [setSimulatorShown]);
+    return (
       <Flex
-        as="section"
-        aria-label={intl.formatMessage({ id: "project-header" })}
-        width="100%"
-        alignItems="center"
-        justifyContent="space-between"
-        pr={flags.simulator && !simulatorShown ? 0 : isWideScreen ? 10 : 5}
-        pl={isWideScreen ? "3rem" : "2rem"}
-        py={2}
-        height={topBarHeight}
+        height="100%"
+        flexDirection="column"
+        {...props}
+        backgroundColor="gray.10"
       >
-        <ProjectNameEditable
-          color="gray.700"
-          opacity="80%"
-          fontSize="xl"
-          data-testid="project-name"
-          clickToEdit
-        />
-        <ActiveFileInfo
-          filename={selection.file}
-          onSelectedFileChanged={onSelectedFileChanged}
-        />
-        <Flex alignItems="center">
-          <ZoomControls display={["none", "none", "none", "flex"]} />
-          {flags.simulator && !simulatorShown && (
-            <HideSplitViewButton
-              aria-label={intl.formatMessage({ id: "simulator-expand" })}
-              handleClick={showSimulator}
-              splitViewShown={simulatorShown}
-              direction="expandLeft"
-              text={intl.formatMessage({ id: "simulator-title" })}
-              ml={5}
-              boxShadow="none"
-              id="simulator-expand"
-            />
-          )}
+        <Flex
+          as="section"
+          aria-label={intl.formatMessage({ id: "project-header" })}
+          width="100%"
+          alignItems="center"
+          justifyContent="space-between"
+          pr={flags.simulator && !simulatorShown ? 0 : isWideScreen ? 10 : 5}
+          pl={isWideScreen ? "3rem" : "2rem"}
+          py={2}
+          height={topBarHeight}
+        >
+          <ProjectNameEditable
+            color="gray.700"
+            opacity="80%"
+            fontSize="xl"
+            data-testid="project-name"
+            clickToEdit
+          />
+          <ActiveFileInfo
+            filename={selection.file}
+            onSelectedFileChanged={onSelectedFileChanged}
+          />
+          <Flex alignItems="center">
+            <ZoomControls display={["none", "none", "none", "flex"]} />
+            {flags.simulator && !simulatorShown && (
+              <HideSplitViewButton
+                aria-label={intl.formatMessage({ id: "simulator-expand" })}
+                handleClick={showSimulator}
+                splitViewShown={simulatorShown}
+                direction="expandLeft"
+                text={intl.formatMessage({ id: "simulator-title" })}
+                ml={5}
+                boxShadow="none"
+                ref={simulatorButtonRef}
+              />
+            )}
+          </Flex>
         </Flex>
-      </Flex>
-      {/* Just for the line */}
-      <Box
-        ml={isWideScreen ? "6rem" : "5rem"}
-        mr={isWideScreen ? "2.5rem" : "1.25rem"}
-        mb={5}
-        width={isWideScreen ? "calc(100% - 8.5rem)" : "calc(100% - 6.25rem)"}
-        borderBottomWidth={2}
-        borderColor="gray.200"
-      />
-      <Box position="relative" flex="1 1 auto" height={0}>
-        <UndoRedoControls
-          display={["none", "none", "none", "flex"]}
-          zIndex="1"
-          top={6}
-          right={isWideScreen ? 10 : 5}
-          position="absolute"
+        {/* Just for the line */}
+        <Box
+          ml={isWideScreen ? "6rem" : "5rem"}
+          mr={isWideScreen ? "2.5rem" : "1.25rem"}
+          mb={5}
+          width={isWideScreen ? "calc(100% - 8.5rem)" : "calc(100% - 6.25rem)"}
+          borderBottomWidth={2}
+          borderColor="gray.200"
         />
-        <EditorContainer selection={selection} />
-      </Box>
-    </Flex>
-  );
-};
+        <Box position="relative" flex="1 1 auto" height={0}>
+          <UndoRedoControls
+            display={["none", "none", "none", "flex"]}
+            zIndex="1"
+            top={6}
+            right={isWideScreen ? 10 : 5}
+            position="absolute"
+          />
+          <EditorContainer selection={selection} />
+        </Box>
+      </Flex>
+    );
+  }
+);
 
 export default EditorArea;

--- a/src/editor/EditorArea.tsx
+++ b/src/editor/EditorArea.tsx
@@ -80,6 +80,7 @@ const EditorArea = ({
               text={intl.formatMessage({ id: "simulator-title" })}
               ml={5}
               boxShadow="none"
+              id="simulator-expand"
             />
           )}
         </Flex>

--- a/src/simulator/Simulator.tsx
+++ b/src/simulator/Simulator.tsx
@@ -16,9 +16,14 @@ import SimulatorSplitView from "./SimulatorSplitView";
 interface SimulatorProps {
   simulatorShown: boolean;
   setSimulatorShown: React.Dispatch<React.SetStateAction<boolean>>;
+  showSimulatorButtonRef: React.RefObject<HTMLButtonElement>;
 }
 
-const Simulator = ({ simulatorShown, setSimulatorShown }: SimulatorProps) => {
+const Simulator = ({
+  simulatorShown,
+  setSimulatorShown,
+  showSimulatorButtonRef,
+}: SimulatorProps) => {
   const ref = useRef<HTMLIFrameElement>(null);
   const intl = useIntl();
   const simulator = useRef(
@@ -43,11 +48,9 @@ const Simulator = ({ simulatorShown, setSimulatorShown }: SimulatorProps) => {
     if (simulatorShown) {
       ref.current!.focus();
     } else {
-      (
-        document.querySelector("#simulator-expand") as HTMLButtonElement
-      ).focus();
+      showSimulatorButtonRef.current!.focus();
     }
-  }, [simulatorShown]);
+  }, [showSimulatorButtonRef, simulatorShown]);
   return (
     <DeviceContextProvider value={simulator.current}>
       <Flex

--- a/src/simulator/Simulator.tsx
+++ b/src/simulator/Simulator.tsx
@@ -39,6 +39,15 @@ const Simulator = ({ simulatorShown, setSimulatorShown }: SimulatorProps) => {
   const hideSimulator = useCallback(() => {
     setSimulatorShown(false);
   }, [setSimulatorShown]);
+  useEffect(() => {
+    if (simulatorShown) {
+      ref.current!.focus();
+    } else {
+      (
+        document.querySelector("#simulator-expand") as HTMLButtonElement
+      ).focus();
+    }
+  }, [simulatorShown]);
   return (
     <DeviceContextProvider value={simulator.current}>
       <Flex

--- a/src/workbench/Workbench.tsx
+++ b/src/workbench/Workbench.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { Box, Flex } from "@chakra-ui/layout";
-import { ReactNode, useCallback, useEffect, useState } from "react";
+import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { useIntl } from "react-intl";
 import {
   SplitView,
@@ -60,6 +60,7 @@ const Workbench = () => {
   const serialSizedMode = connected ? serialStateWhenOpen : "collapsed";
   const [sidebarShown, setSidebarShown] = useState<boolean>(true);
   const [simulatorShown, setSimulatorShown] = useState<boolean>(true);
+  const simulatorButtonRef = useRef<HTMLButtonElement>(null);
   const editor = (
     <Box height="100%" as="section">
       {selection && fileVersion !== undefined && (
@@ -69,6 +70,7 @@ const Workbench = () => {
           onSelectedFileChanged={setSelectedFile}
           setSimulatorShown={setSimulatorShown}
           simulatorShown={simulatorShown}
+          ref={simulatorButtonRef}
         />
       )}
     </Box>
@@ -108,6 +110,7 @@ const Workbench = () => {
                 setSerialStateWhenOpen={setSerialStateWhenOpen}
                 setSimulatorShown={setSimulatorShown}
                 simulatorShown={simulatorShown}
+                showSimulatorButtonRef={simulatorButtonRef}
               />
             ) : (
               <Editor
@@ -133,6 +136,7 @@ interface EditorProps {
 interface EditorWithSimulatorProps extends EditorProps {
   simulatorShown: boolean;
   setSimulatorShown: React.Dispatch<React.SetStateAction<boolean>>;
+  showSimulatorButtonRef: React.RefObject<HTMLButtonElement>;
 }
 
 const EditorWithSimulator = ({
@@ -141,6 +145,7 @@ const EditorWithSimulator = ({
   editor,
   simulatorShown,
   setSimulatorShown,
+  showSimulatorButtonRef,
 }: EditorWithSimulatorProps) => {
   return (
     <SplitView
@@ -161,6 +166,7 @@ const EditorWithSimulator = ({
         <Simulator
           setSimulatorShown={setSimulatorShown}
           simulatorShown={simulatorShown}
+          showSimulatorButtonRef={showSimulatorButtonRef}
         />
       </SplitViewSized>
     </SplitView>


### PR DESCRIPTION
This now mimics the tab focus behaviour for the left hand sidebar on expand and collapse.