### PR TITLE
Layout defaults with and without the sim.

### DIFF
--- a/src/common/SplitView/HideSplitViewButton.tsx
+++ b/src/common/SplitView/HideSplitViewButton.tsx
@@ -10,7 +10,7 @@ import CollapsibleButton from "../CollapsibleButton";
 import { splitViewHideButton } from "../zIndex";
 
 interface HideSplitViewButtonProps extends IconButtonProps {
-  handleClick: () => void;
+  onClick: () => void;
   direction: "expandLeft" | "expandRight";
   splitViewShown: boolean;
   text?: string;
@@ -19,7 +19,7 @@ interface HideSplitViewButtonProps extends IconButtonProps {
 const HideSplitViewButton = React.forwardRef(
   (
     {
-      handleClick,
+      onClick,
       direction,
       splitViewShown,
       text = "",
@@ -61,7 +61,7 @@ const HideSplitViewButton = React.forwardRef(
           icon={<Icon as={RiDownloadLine} transform={rotation} />}
           fontSize="lg"
           transition="none"
-          onClick={handleClick}
+          onClick={onClick}
           borderTopRightRadius={rightBorderRadius}
           borderBottomRightRadius={rightBorderRadius}
           borderTopLeftRadius={leftBorderRadius}

--- a/src/common/screenWidthUtils.ts
+++ b/src/common/screenWidthUtils.ts
@@ -1,0 +1,9 @@
+/**
+ * (c) 2022, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { flags } from "../flags";
+
+export const widthToHideSidebar = flags.simulator ? 1376 : 1110;
+export const sidebarToWidthRatio = flags.simulator ? 0.27 : 0.35;

--- a/src/editor/EditorArea.tsx
+++ b/src/editor/EditorArea.tsx
@@ -4,24 +4,24 @@
  * SPDX-License-Identifier: MIT
  */
 import { Box, BoxProps, Flex, useMediaQuery } from "@chakra-ui/react";
+import React, { ForwardedRef } from "react";
 import { useIntl } from "react-intl";
+import { widthXl } from "../common/media-queries";
+import HideSplitViewButton from "../common/SplitView/HideSplitViewButton";
 import { topBarHeight } from "../deployment/misc";
+import ZoomControls from "../editor/ZoomControls";
+import { flags } from "../flags";
 import ProjectNameEditable from "../project/ProjectNameEditable";
 import { WorkbenchSelection } from "../workbench/use-selection";
 import ActiveFileInfo from "./ActiveFileInfo";
 import EditorContainer from "./EditorContainer";
-import ZoomControls from "../editor/ZoomControls";
 import UndoRedoControls from "./UndoRedoControls";
-import { widthXl } from "../common/media-queries";
-import HideSplitViewButton from "../common/SplitView/HideSplitViewButton";
-import React, { ForwardedRef, useCallback } from "react";
-import { flags } from "../flags";
 
 interface EditorAreaProps extends BoxProps {
   selection: WorkbenchSelection;
   onSelectedFileChanged: (filename: string) => void;
   simulatorShown: boolean;
-  setSimulatorShown: React.Dispatch<React.SetStateAction<boolean>>;
+  onSimulatorExpand: () => void;
 }
 
 /**
@@ -34,16 +34,13 @@ const EditorArea = React.forwardRef(
       selection,
       onSelectedFileChanged,
       simulatorShown,
-      setSimulatorShown,
+      onSimulatorExpand,
       ...props
     }: EditorAreaProps,
     simulatorButtonRef: ForwardedRef<HTMLButtonElement>
   ) => {
     const intl = useIntl();
     const [isWideScreen] = useMediaQuery(widthXl);
-    const showSimulator = useCallback(() => {
-      setSimulatorShown(true);
-    }, [setSimulatorShown]);
     return (
       <Flex
         height="100%"
@@ -78,7 +75,7 @@ const EditorArea = React.forwardRef(
             {flags.simulator && !simulatorShown && (
               <HideSplitViewButton
                 aria-label={intl.formatMessage({ id: "simulator-expand" })}
-                handleClick={showSimulator}
+                onClick={onSimulatorExpand}
                 splitViewShown={simulatorShown}
                 direction="expandLeft"
                 text={intl.formatMessage({ id: "simulator-title" })}

--- a/src/simulator/Simulator.tsx
+++ b/src/simulator/Simulator.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { AspectRatio, Box, Flex, useToken, VStack } from "@chakra-ui/react";
-import { useCallback, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { useIntl } from "react-intl";
 import HideSplitViewButton from "../common/SplitView/HideSplitViewButton";
 import { topBarHeight } from "../deployment/misc";
@@ -14,15 +14,15 @@ import SimulatorActionBar from "./SimulatorActionBar";
 import SimulatorSplitView from "./SimulatorSplitView";
 
 interface SimulatorProps {
-  simulatorShown: boolean;
-  setSimulatorShown: React.Dispatch<React.SetStateAction<boolean>>;
+  shown: boolean;
+  onSimulatorHide: () => void;
   showSimulatorButtonRef: React.RefObject<HTMLButtonElement>;
   minWidth: number;
 }
 
 const Simulator = ({
-  simulatorShown,
-  setSimulatorShown,
+  shown,
+  onSimulatorHide,
   showSimulatorButtonRef,
   minWidth,
 }: SimulatorProps) => {
@@ -43,16 +43,15 @@ const Simulator = ({
   const simControlsRef = useRef<HTMLDivElement>(null);
   const simHeight = simControlsRef.current?.offsetHeight || 0;
   const [brand500] = useToken("colors", ["brand.500"]);
-  const hideSimulator = useCallback(() => {
-    setSimulatorShown(false);
-  }, [setSimulatorShown]);
+
   useEffect(() => {
-    if (simulatorShown) {
+    if (shown) {
       ref.current!.focus();
     } else {
       showSimulatorButtonRef.current!.focus();
     }
-  }, [showSimulatorButtonRef, simulatorShown]);
+  }, [showSimulatorButtonRef, shown]);
+
   return (
     <DeviceContextProvider value={simulator.current}>
       <Flex
@@ -70,8 +69,8 @@ const Simulator = ({
         >
           <HideSplitViewButton
             aria-label={intl.formatMessage({ id: "simulator-collapse" })}
-            handleClick={hideSimulator}
-            splitViewShown={simulatorShown}
+            onClick={onSimulatorHide}
+            splitViewShown={shown}
             direction="expandLeft"
           />
         </Flex>

--- a/src/workbench/SideBarHeader.tsx
+++ b/src/workbench/SideBarHeader.tsx
@@ -275,7 +275,7 @@ const SideBarHeader = ({
                   ? intl.formatMessage({ id: "sidebar-collapse" })
                   : intl.formatMessage({ id: "sidebar-expand" })
               }
-              handleClick={handleCollapseBtnClick}
+              onClick={handleCollapseBtnClick}
               splitViewShown={sidebarShown}
               direction="expandRight"
             />

--- a/src/workbench/Workbench.tsx
+++ b/src/workbench/Workbench.tsx
@@ -59,13 +59,13 @@ const Workbench = () => {
 
   const fileVersion = files.find((f) => f.name === selection.file)?.version;
 
-  const [sidebarShown, setSidebarShown] = useState<boolean>(() =>
-    flags.simulator ? window.innerWidth > widthToHideSidebar : true
+  const [sidebarShown, setSidebarShown] = useState<boolean>(
+    () => window.innerWidth > widthToHideSidebar
   );
   const [simulatorShown, setSimulatorShown] = useState<boolean>(true);
   const simulatorButtonRef = useRef<HTMLButtonElement>(null);
   const [tabIndex, setTabIndex] = useState<number>(() =>
-    flags.simulator && window.innerWidth <= widthToHideSidebar ? -1 : 0
+    window.innerWidth > widthToHideSidebar ? 0 : -1
   );
 
   // Sidebar/simulator space management:


### PR DESCRIPTION
Toggle one off and the other on as needed to preserve space.
Initial space is still tight.
You can also lose buttons as we never hide on window resize.