### PR TITLE
Hide sidebar on resize.

### DIFF
--- a/src/common/screenWidthUtils.ts
+++ b/src/common/screenWidthUtils.ts
@@ -7,3 +7,4 @@ import { flags } from "../flags";
 
 export const widthToHideSidebar = flags.simulator ? 1376 : 1110;
 export const sidebarToWidthRatio = flags.simulator ? 0.27 : 0.35;
+export const hideSidebarMediaQuery = `(max-width: ${widthToHideSidebar - 1}px)`;

--- a/src/workbench/Workbench.tsx
+++ b/src/workbench/Workbench.tsx
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: MIT
  */
 import { Box, Flex } from "@chakra-ui/layout";
+import { useMediaQuery } from "@chakra-ui/react";
 import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { useIntl } from "react-intl";
 import {
+  hideSidebarMediaQuery,
   sidebarToWidthRatio,
   widthToHideSidebar,
 } from "../common/screenWidthUtils";
@@ -90,6 +92,12 @@ const Workbench = () => {
       handleSidebarCollapse();
     }
   }, [handleSidebarCollapse]);
+  const [hideSideBarMediaQueryValue] = useMediaQuery(hideSidebarMediaQuery);
+  useEffect(() => {
+    if (hideSideBarMediaQueryValue) {
+      handleSidebarCollapse();
+    }
+  }, [hideSideBarMediaQueryValue, handleSidebarCollapse]);
 
   const editor = (
     <Box height="100%" as="section">


### PR DESCRIPTION
Maintains visibility of the project action bar buttons.