### PR TITLE
Simulator serial tweaks.

### DIFF
--- a/src/serial/SerialArea.tsx
+++ b/src/serial/SerialArea.tsx
@@ -17,12 +17,14 @@ interface SerialAreaProps extends BoxProps {
   onSizeChange: (size: "compact" | "open") => void;
   showSyncStatus: boolean;
   terminalFontSizePt?: number;
-  showExpandText?: boolean;
+  hideExpandTextOnTraceback?: boolean;
   showHintsAndTips?: boolean;
 }
 
 /**
- * The serial area below the editor.
+ * The serial area.
+ *
+ * This is used below the editor (connected via WebUSB) and in the simulator.
  *
  * This has a compact and expanded form and coordinates its
  * size with the workspace layout via compact/onSizeChange.
@@ -33,7 +35,7 @@ const SerialArea = ({
   showSyncStatus,
   terminalFontSizePt,
   expandDirection,
-  showExpandText = true,
+  hideExpandTextOnTraceback = false,
   showHintsAndTips = true,
   ...props
 }: SerialAreaProps) => {
@@ -61,7 +63,7 @@ const SerialArea = ({
               onSizeChange={onSizeChange}
               showSyncStatus={showSyncStatus}
               expandDirection={expandDirection}
-              showExpandText={showExpandText}
+              hideExpandTextOnTraceback={hideExpandTextOnTraceback}
               showHintsAndTips={showHintsAndTips}
             />
             <XTerm

--- a/src/serial/SerialBar.tsx
+++ b/src/serial/SerialBar.tsx
@@ -24,7 +24,7 @@ interface SerialBarProps extends BoxProps {
   onSizeChange: (size: "compact" | "open") => void;
   showSyncStatus: boolean;
   expandDirection: "up" | "down";
-  showExpandText: boolean;
+  hideExpandTextOnTraceback: boolean;
   showHintsAndTips: boolean;
 }
 
@@ -36,7 +36,7 @@ const SerialBar = ({
   onSizeChange,
   background,
   showSyncStatus,
-  showExpandText,
+  hideExpandTextOnTraceback,
   showHintsAndTips,
   expandDirection,
   ...props
@@ -52,6 +52,10 @@ const SerialBar = ({
   const helpDisclosure = useDisclosure();
   const traceback = useDeviceTraceback();
   const syncStatus = useSyncStatus();
+  const handleShowHintsAndTips = useCallback(() => {
+    logging.event({ type: "serial-info" });
+    helpDisclosure.onOpen();
+  }, [logging, helpDisclosure]);
   return (
     <>
       <SerialHelpDialog
@@ -79,7 +83,11 @@ const SerialBar = ({
 
         <HStack>
           <CollapsibleButton
-            mode={showExpandText ? "button" : "icon"}
+            mode={
+              hideExpandTextOnTraceback && compact && traceback
+                ? "icon"
+                : "button"
+            }
             variant="unstyled"
             display="flex"
             fontWeight="normal"
@@ -106,13 +114,17 @@ const SerialBar = ({
                 isRound
                 aria-label={intl.formatMessage({ id: "serial-hints-and-tips" })}
                 icon={<RiInformationLine />}
-                onClick={() => {
-                  logging.event({ type: "serial-info" });
-                  helpDisclosure.onOpen();
-                }}
+                onClick={handleShowHintsAndTips}
               />
             )}
-            <SerialMenu compact={compact} onSizeChange={onSizeChange} />
+            <SerialMenu
+              compact={compact}
+              onSizeChange={onSizeChange}
+              // Move it to the menu if not shown more visibly.
+              onShowHintsAndTips={
+                !showHintsAndTips ? handleShowHintsAndTips : undefined
+              }
+            />
           </HStack>
         </HStack>
       </HStack>

--- a/src/serial/SerialMenu.tsx
+++ b/src/serial/SerialMenu.tsx
@@ -7,12 +7,13 @@ import {
   IconButton,
   Menu,
   MenuButton,
+  MenuDivider,
   MenuItem,
   MenuList,
   Portal,
 } from "@chakra-ui/react";
 import { MdMoreVert } from "react-icons/md";
-import { RiKeyboardBoxLine } from "react-icons/ri";
+import { RiInformationLine, RiKeyboardBoxLine } from "react-icons/ri";
 import { FormattedMessage, useIntl } from "react-intl";
 import { zIndexAboveTerminal } from "../common/zIndex";
 import { useSerialActions } from "./serial-hooks";
@@ -20,12 +21,17 @@ import { useSerialActions } from "./serial-hooks";
 interface SerialMenuProps {
   compact?: boolean;
   onSizeChange: (size: "compact" | "open") => void;
+  onShowHintsAndTips?: () => void;
 }
 
 /**
  * Serial ara drop-down menu.
  */
-const SerialMenu = ({ compact, onSizeChange }: SerialMenuProps) => {
+const SerialMenu = ({
+  compact,
+  onSizeChange,
+  onShowHintsAndTips,
+}: SerialMenuProps) => {
   const intl = useIntl();
   const actions = useSerialActions(onSizeChange);
   return (
@@ -46,6 +52,17 @@ const SerialMenu = ({ compact, onSizeChange }: SerialMenuProps) => {
           <MenuItem icon={<RiKeyboardBoxLine />} onClick={actions.reset}>
             <FormattedMessage id="serial-ctrl-d-action" />
           </MenuItem>
+          {onShowHintsAndTips && (
+            <>
+              <MenuDivider />
+              <MenuItem
+                icon={<RiInformationLine />}
+                onClick={onShowHintsAndTips}
+              >
+                <FormattedMessage id="serial-hints-and-tips" />
+              </MenuItem>
+            </>
+          )}
         </MenuList>
       </Portal>
     </Menu>

--- a/src/simulator/SimulatorSplitView.tsx
+++ b/src/simulator/SimulatorSplitView.tsx
@@ -51,7 +51,7 @@ const SimulatorSplitView = ({
           aria-label={intl.formatMessage({
             id: "simulator-serial-terminal",
           })}
-          showExpandText={false}
+          hideExpandTextOnTraceback={true}
           showSyncStatus={false}
           showHintsAndTips={false}
         />


### PR DESCRIPTION
- Show the hints and tips entry for sim serial, but on the menu due to
  lack of space.
- Show the expand/collapse text, but deconflict with the traceback on
  the sim due to lack of space. We decided this is important to
  understand that it is the serial area as it's otherwise unlabelled.